### PR TITLE
Update to valid params and remove PresetBC from tests

### DIFF
--- a/examples/euler_angle-reader/cpfem_eulerTest.i
+++ b/examples/euler_angle-reader/cpfem_eulerTest.i
@@ -126,10 +126,11 @@
   [../]
 
   [./front]
-    type = FunctionPresetBC
+    type = FunctionDirichletBC
     variable = disp_y
     boundary = top
     function = pfn
+    preset = true
   [../]
 []
 

--- a/examples/euler_angle-reader/cpfem_eulerTest.i
+++ b/examples/euler_angle-reader/cpfem_eulerTest.i
@@ -102,21 +102,24 @@
 []
 [BCs]
   [./left]
-     type = PresetBC
+     type = DirichletBC
+     preset = true
      variable = disp_x
      boundary = left
      value = 0.0
   [../]
 
   [./bottom]
-    type = PresetBC
+    type = DirichletBC
+     preset = true
     variable = disp_y
     boundary = bottom
     value = 0.0
   [../]
 
   [./back]
-    type = PresetBC
+    type = DirichletBC
+     preset = true
     variable = disp_z
     boundary = back
     value = 0.0

--- a/examples/euler_angle-reader/small_eulerTest.i
+++ b/examples/euler_angle-reader/small_eulerTest.i
@@ -25,19 +25,22 @@
 []
 [BCs]
   [./leftx]
-    type = PresetBC
+    type = DirichletBC
+    preset = true
     boundary = left
     variable = disp_x
     value = 0.0
   [../]
   [./lefty]
-    type = PresetBC
+    type = DirichletBC
+    preset = true
     boundary = back
     variable = disp_y
     value = 0.0
   [../]
   [./leftz]
-    type = PresetBC
+    type = DirichletBC
+    preset = true
     boundary = bottom
     variable = disp_z
     value = 0.0

--- a/examples/euler_angle-reader/small_eulerTest.i
+++ b/examples/euler_angle-reader/small_eulerTest.i
@@ -46,10 +46,11 @@
     value = 0.0
   [../]
   [./pull_z]
-    type = FunctionPresetBC
+    type = FunctionDirichletBC
     boundary = top
     variable = disp_z
     function = pfn
+    preset = true
   [../]
 []
 

--- a/examples/nemltester_T.i
+++ b/examples/nemltester_T.i
@@ -59,25 +59,29 @@
 
 [BCs]
       [./left]
-            type = PresetBC
+            type = DirichletBC
+            preset = true
             variable = disp_x
             value = 0.0
             boundary = 'left'
       [../]
       [./back]
-            type = PresetBC
+            type = DirichletBC
+            preset = true
             variable = disp_y
             value = 0.0
             boundary = 'back'
       [../]
       [./bottom]
-            type = PresetBC
+            type = DirichletBC
+            preset = true
             variable = disp_z
             value = 0.0
             boundary = 'bottom'
       [../]
       [./top]
-            type = PresetBC
+            type = DirichletBC
+            preset = true
             variable = disp_z
             boundary = 'top'
             value = 0.0
@@ -87,10 +91,10 @@
 [Executioner]
       type = Transient
       solve_type = PJFNK
-      
+
       petsc_options_iname = '-pc_type -pc_hypre_type -ksp_gmres_restart'
       petsc_options_value = 'hypre boomeramg 101'
-      
+
       nl_max_its = 20
       nl_rel_tol = 1.0e-6
       nl_abs_tol = 1.0e-10

--- a/examples/nemltester_noT.i
+++ b/examples/nemltester_noT.i
@@ -67,10 +67,11 @@
             boundary = 'bottom'
       [../]
       [./top]
-            type = FunctionPresetBC
+            type = FunctionDirichletBC
             variable = disp_z
             boundary = 'top'
             function = straining
+            preset = true
       [../]
 []
 

--- a/examples/nemltester_noT.i
+++ b/examples/nemltester_noT.i
@@ -46,19 +46,22 @@
 
 [BCs]
       [./left]
-            type = PresetBC
+            type = DirichletBC
+            preset = true
             variable = disp_x
             value = 0.0
             boundary = 'left'
       [../]
       [./back]
-            type = PresetBC
+            type = DirichletBC
+            preset = true
             variable = disp_y
             value = 0.0
             boundary = 'back'
       [../]
       [./bottom]
-            type = PresetBC
+            type = DirichletBC
+            preset = true
             variable = disp_z
             value = 0.0
             boundary = 'bottom'
@@ -74,10 +77,10 @@
 [Executioner]
       type = Transient
       solve_type = PJFNK
-      
+
       petsc_options_iname = '-pc_type -pc_hypre_type -ksp_gmres_restart'
       petsc_options_value = 'hypre boomeramg 101'
-      
+
       nl_max_its = 20
       nl_rel_tol = 1.0e-6
       nl_abs_tol = 1.0e-10

--- a/include/actions/NEMLMechanicsAction.h
+++ b/include/actions/NEMLMechanicsAction.h
@@ -5,17 +5,14 @@
 
 class NEMLMechanicsAction;
 
-template <>
-InputParameters validParams<NEMLMechanicsAction>();
-
-class NEMLMechanicsAction : public Action
-{
- public:
-  NEMLMechanicsAction(const InputParameters & params);
+class NEMLMechanicsAction : public Action {
+public:
+  static InputParameters validParams();
+  NEMLMechanicsAction(const InputParameters &params);
 
   virtual void act();
 
- protected:
+protected:
   void _add_tensor_variable(std::string name);
   void _add_scalar_variable(std::string name);
 
@@ -27,17 +24,12 @@ class NEMLMechanicsAction : public Action
   bool _add_disp;
   bool _add_all;
 
-  enum class Kinematics
-  {
-    Small,
-    Large
-  } _kinematics;
+  enum class Kinematics { Small, Large } _kinematics;
 
-  std::map<Kinematics, bool> _kin_mapper = {
-    {Kinematics::Small, false},
-    {Kinematics::Large, true}};
+  std::map<Kinematics, bool> _kin_mapper = {{Kinematics::Small, false},
+                                            {Kinematics::Large, true}};
 
-  std::vector<MaterialPropertyName> _eigenstrains;  
+  std::vector<MaterialPropertyName> _eigenstrains;
 };
 
 #endif // NEMLMECHANICSACTION_H

--- a/include/actions/NEMLMechanicsAction.h
+++ b/include/actions/NEMLMechanicsAction.h
@@ -1,9 +1,6 @@
-#ifndef NEMLMECHANICSACTION_H
-#define NEMLMECHANICSACTION_H
+#pragma once
 
 #include "Action.h"
-
-class NEMLMechanicsAction;
 
 class NEMLMechanicsAction : public Action {
 public:
@@ -31,5 +28,3 @@ protected:
 
   std::vector<MaterialPropertyName> _eigenstrains;
 };
-
-#endif // NEMLMECHANICSACTION_H

--- a/include/auxkernels/TimeDerivAuxKernel.h
+++ b/include/auxkernels/TimeDerivAuxKernel.h
@@ -5,21 +5,17 @@
 
 class TimeDerivAuxKernel;
 
-template <>
-InputParameters validParams<TimeDerivAuxKernel>();
+class TimeDerivAuxKernel : public AuxKernel {
+public:
+  static InputParameters validParams();
+  TimeDerivAuxKernel(const InputParameters &parameters);
 
-class TimeDerivAuxKernel: public AuxKernel
-{
- public:
-  TimeDerivAuxKernel(const InputParameters & parameters);
-
- protected:
+protected:
   virtual Real computeValue() override;
 
- protected:
-  const VariableValue & _coupled_new;
-  const VariableValue & _coupled_old;
+protected:
+  const VariableValue &_coupled_new;
+  const VariableValue &_coupled_old;
 };
-
 
 #endif // TIMEDERIVAUXKERNEL_H

--- a/include/auxkernels/TimeDerivAuxKernel.h
+++ b/include/auxkernels/TimeDerivAuxKernel.h
@@ -1,9 +1,6 @@
-#ifndef TIMEDERIVAUXKERNEL_H
-#define TIMEDERIVAUXKERNEL_H
+#pragma once
 
 #include "AuxKernel.h"
-
-class TimeDerivAuxKernel;
 
 class TimeDerivAuxKernel : public AuxKernel {
 public:
@@ -17,5 +14,3 @@ protected:
   const VariableValue &_coupled_new;
   const VariableValue &_coupled_old;
 };
-
-#endif // TIMEDERIVAUXKERNEL_H

--- a/include/auxkernels/TractionAux.h
+++ b/include/auxkernels/TractionAux.h
@@ -19,11 +19,9 @@ class TractionAux;
  * material property, for example stress or strain, and output the value for the
  * supplied indices.
  */
-
-template <> InputParameters validParams<TractionAux>();
-
 class TractionAux : public MaterialAuxBase<RankTwoTensor> {
 public:
+  static InputParameters validParams();
   TractionAux(const InputParameters &parameters);
 
 protected:
@@ -32,5 +30,5 @@ protected:
   const MooseEnum _scalar_type;
 
 private:
-  MooseEnum traction_component();
+  static MooseEnum traction_component();
 };

--- a/include/base/DeerApp.h
+++ b/include/base/DeerApp.h
@@ -3,19 +3,14 @@
 
 #include "MooseApp.h"
 
-class DeerApp;
-
-template<>
-InputParameters validParams<DeerApp>();
-
-class DeerApp : public MooseApp
-{
+class DeerApp : public MooseApp {
 public:
+  static InputParameters validParams();
   DeerApp(InputParameters parameters);
   virtual ~DeerApp();
 
   static void registerApps();
-  static void registerAll(Factory & f, ActionFactory & af, Syntax & s);
+  static void registerAll(Factory &f, ActionFactory &af, Syntax &s);
 };
 
 #endif /* DEERAPP_H */

--- a/include/base/DeerApp.h
+++ b/include/base/DeerApp.h
@@ -1,5 +1,4 @@
-#ifndef DEERAPP_H
-#define DEERAPP_H
+#pragma once
 
 #include "MooseApp.h"
 
@@ -12,5 +11,3 @@ public:
   static void registerApps();
   static void registerAll(Factory &f, ActionFactory &af, Syntax &s);
 };
-
-#endif /* DEERAPP_H */

--- a/include/functions/CapGradient.h
+++ b/include/functions/CapGradient.h
@@ -1,29 +1,19 @@
-#ifndef CAPGRADIENT_H
-#define CAPGRADIENT_H
+#pragma once
 
 #include "Function.h"
 
-class CapGradient;
+class CapGradient : public Function {
+public:
+  static InputParameters validParams();
+  CapGradient(const InputParameters &parameters);
 
-template <>
-InputParameters validParams<CapGradient>();
+  virtual Real value(Real t, const Point &p);
 
-class CapGradient : public Function
-{
- public:
-  CapGradient(const InputParameters & parameters);
-
-  virtual Real value(Real t, const Point & p);
-
- private:
+private:
   Real _getTemp(Real T2p, Real nx);
 
- protected:
-  Real _delay, _T1, _T2, _tramp1, _thold1, _tramp2, _thold2, _r1, _r2, _trans, _radius;
+protected:
+  Real _delay, _T1, _T2, _tramp1, _thold1, _tramp2, _thold2, _r1, _r2, _trans,
+      _radius;
   int _index;
-
 };
-
-
-
-#endif // CAPGRADIENT_H

--- a/include/functions/CycleFraction.h
+++ b/include/functions/CycleFraction.h
@@ -11,12 +11,9 @@
 
 #include "Function.h"
 
-class CycleFraction;
-
-template <> InputParameters validParams<CycleFraction>();
-
 class CycleFraction : public Function {
 public:
+  static InputParameters validParams();
   CycleFraction(const InputParameters &parameters);
 
   Real value(Real t, const Point &p) const override;

--- a/include/functions/CycleNumber.h
+++ b/include/functions/CycleNumber.h
@@ -13,13 +13,10 @@
 
 class CycleNumber;
 
-template <>
-InputParameters validParams<CycleNumber>();
-
-class CycleNumber : public Function
-{
+class CycleNumber : public Function {
 public:
-  CycleNumber(const InputParameters & parameters);
+  static InputParameters validParams();
+  CycleNumber(const InputParameters &parameters);
 
   Real value(Real t, const Point &p) const override;
 

--- a/include/functions/CycleTime.h
+++ b/include/functions/CycleTime.h
@@ -11,12 +11,9 @@
 
 #include "Function.h"
 
-class CycleTime;
-
-template <> InputParameters validParams<CycleTime>();
-
 class CycleTime : public Function {
 public:
+  static InputParameters validParams();
   CycleTime(const InputParameters &parameters);
 
   Real value(Real t, const Point &p) const override;

--- a/include/functions/PiecewiseLinearCycle.h
+++ b/include/functions/PiecewiseLinearCycle.h
@@ -13,11 +13,6 @@
 #include "FunctionInterface.h"
 #include "PiecewiseLinear.h"
 
-// Forward declarations
-class PiecewiseLinearCycle;
-
-template <> InputParameters validParams<PiecewiseLinearCycle>();
-
 /**
  * Function which provides a PiecewiseLinear continuous linear interpolation
  * of a provided (x,y) point data set.
@@ -25,6 +20,7 @@ template <> InputParameters validParams<PiecewiseLinearCycle>();
 class PiecewiseLinearCycle : public PiecewiseLinear,
                              protected FunctionInterface {
 public:
+  static InputParameters validParams();
   PiecewiseLinearCycle(const InputParameters &parameters);
 
   /**

--- a/include/functions/ThicknessGradient.h
+++ b/include/functions/ThicknessGradient.h
@@ -1,29 +1,18 @@
-#ifndef THICKNESSGRADIENT_H
-#define THICKNESSGRADIENT_H
+#pragma once
 
 #include "Function.h"
 
-class ThicknessGradient;
+class ThicknessGradient : public Function {
+public:
+  static InputParameters validParams();
+  ThicknessGradient(const InputParameters &parameters);
 
-template <>
-InputParameters validParams<ThicknessGradient>();
+  virtual Real value(Real t, const Point &p);
 
-class ThicknessGradient : public Function
-{
- public:
-  ThicknessGradient(const InputParameters & parameters);
-
-  virtual Real value(Real t, const Point & p);
-
- private:
+private:
   Real _getTemp(Real T2p, Real nx);
 
- protected:
+protected:
   Real _delay, _T1, _T2, _tramp1, _thold1, _tramp2, _thold2, _x1, _x2;
   int _index;
-
 };
-
-
-
-#endif // THICKNESSGRADIENT_H

--- a/include/kernels/StressDivergenceNEML.h
+++ b/include/kernels/StressDivergenceNEML.h
@@ -1,23 +1,17 @@
-#ifndef STRESSDIVERGENCENEML_H
-#define STRESSDIVERGENCENEML_H
+#pragma once
 
-#include "Kernel.h"
 #include "DerivativeMaterialInterface.h"
-#include "RankTwoTensor.h"
+#include "Kernel.h"
 #include "RankFourTensor.h"
+#include "RankTwoTensor.h"
 
-class StressDivergenceNEML;
+class StressDivergenceNEML : public DerivativeMaterialInterface<Kernel> {
+public:
+  static InputParameters validParams();
+  StressDivergenceNEML(const InputParameters &parameters);
+  virtual ~StressDivergenceNEML(){};
 
-template <>
-InputParameters validParams<StressDivergenceNEML>();
-
-class StressDivergenceNEML: public DerivativeMaterialInterface<Kernel>
-{
- public:
-  StressDivergenceNEML(const InputParameters & parameters);
-  virtual ~StressDivergenceNEML() {};
-  
- protected:
+protected:
   virtual void initialSetup() override;
 
   // These must be overwritten for Bbar-type stabilizations
@@ -30,33 +24,30 @@ class StressDivergenceNEML: public DerivativeMaterialInterface<Kernel>
   virtual Real computeQpJacobian() override;
   virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
 
- private:
-  Real matJacobianComponent(const RankFourTensor & C,
-                            unsigned int i, unsigned int m,
-                            const RealGradient & grad_psi,
-                            const RealGradient & grad_phi,
-                            const RankTwoTensor & df);
+private:
+  Real matJacobianComponent(const RankFourTensor &C, unsigned int i,
+                            unsigned int m, const RealGradient &grad_psi,
+                            const RealGradient &grad_phi,
+                            const RankTwoTensor &df);
   Real geomJacobianComponent(unsigned int i, unsigned int m,
-                             const RealGradient & grad_psi,
-                             const RealGradient & grad_phi,
-                             const RankTwoTensor & stress);
+                             const RealGradient &grad_psi,
+                             const RealGradient &grad_phi,
+                             const RankTwoTensor &stress);
 
- protected:
+protected:
   bool _ld;
 
   unsigned int _component;
   unsigned int _ndisp;
 
   std::vector<unsigned int> _disp_nums;
-  std::vector<MooseVariable*> _disp_vars;
+  std::vector<MooseVariable *> _disp_vars;
   std::vector<const VariableGradient *> _grad_disp;
 
-  const MaterialProperty<RankTwoTensor> & _stress;
-  const MaterialProperty<RankFourTensor> & _material_jacobian;
+  const MaterialProperty<RankTwoTensor> &_stress;
+  const MaterialProperty<RankFourTensor> &_material_jacobian;
 
-  const MaterialProperty<RankTwoTensor> & _df;
+  const MaterialProperty<RankTwoTensor> &_df;
 };
 
-Real det(const RankTwoTensor & T);
-
-#endif // STRESSDIVERGENCENEML_H
+Real det(const RankTwoTensor &T);

--- a/include/materials/ComputeNEMLCPOutput.h
+++ b/include/materials/ComputeNEMLCPOutput.h
@@ -1,43 +1,34 @@
-#ifndef COMPUTENEMLCPOUTPUT_H
-#define COMPUTENEMLCPOUTPUT_H
+#pragma once
 
 #include "ComputeNEMLStressUpdate.h"
 #include "EulerAngleProvider.h"
 
-class ComputeNEMLCPOutput;
+class ComputeNEMLCPOutput : public ComputeNEMLStressUpdate {
+public:
+  static InputParameters validParams();
+  ComputeNEMLCPOutput(const InputParameters &parameters);
+  virtual ~ComputeNEMLCPOutput(){};
 
-template <>
-InputParameters validParams<ComputeNEMLCPOutput>();
+protected:
+  neml::SingleCrystalModel *_cpmodel = nullptr;
 
-class ComputeNEMLCPOutput: public ComputeNEMLStressUpdate
-{
- public:
-  ComputeNEMLCPOutput(const InputParameters & parameters);
-  virtual ~ComputeNEMLCPOutput() {};
+  MaterialProperty<std::vector<Real>> &_orientation_q;
+  /// object providing the Euler angles
+  const EulerAngleProvider *_euler;
+  /// grain id
+  unsigned int _grain;
+  unsigned int _given = 1;
 
- protected:
-   neml::SingleCrystalModel *_cpmodel = nullptr;
+  virtual void initQpStatefulProperties() override;
 
-   MaterialProperty<std::vector<Real>> & _orientation_q;
-   /// object providing the Euler angles
-   const EulerAngleProvider * _euler;
-   /// grain id
-   unsigned int _grain;
-   unsigned int _given = 1;
+  virtual void stressUpdate(const double *const e_np1, const double *const e_n,
+                            const double *const w_np1, const double *const w_n,
+                            double T_np1, double T_n, double t_np1, double t_n,
+                            double *const s_np1, const double *const s_n,
+                            double *const h_np1, const double *const h_n,
+                            double *const A_np1, double *const B_np1,
+                            double &u_np1, double u_n, double &p_np1,
+                            double p_n);
 
-   virtual void initQpStatefulProperties() override;
-
-   virtual void stressUpdate(
-       const double * const e_np1, const double * const e_n,
-       const double * const w_np1, const double * const w_n,
-       double T_np1, double T_n, double t_np1, double t_n,
-       double * const s_np1, const double * const s_n,
-       double * const h_np1, const double * const h_n,
-       double * const A_np1, double * const B_np1,
-       double & u_np1, double u_n, double & p_np1, double p_n);
-
-   void getCPOutput(double *const h_np1);
+  void getCPOutput(double *const h_np1);
 };
-
-
-#endif // COMPUTENEMLCPOUTPUT_H

--- a/include/materials/ComputeNEMLStrain.h
+++ b/include/materials/ComputeNEMLStrain.h
@@ -1,22 +1,14 @@
-#ifndef COMPUTENEMLSTRAIN_H
-#define COMPUTENEMLSTRAIN_H
+#pragma once
 
-#include "RankTwoTensor.h"
 #include "ComputeNEMLStrainBase.h"
+#include "RankTwoTensor.h"
 
-class ComputeNEMLStrain;
+class ComputeNEMLStrain : public ComputeNEMLStrainBase {
+public:
+  static InputParameters validParams();
+  ComputeNEMLStrain(const InputParameters &parameters);
+  virtual ~ComputeNEMLStrain(){};
 
-template <>
-InputParameters validParams<ComputeNEMLStrain>();
-
-class ComputeNEMLStrain: public ComputeNEMLStrainBase
-{
- public:
-  ComputeNEMLStrain(const InputParameters & parameters);
-  virtual ~ComputeNEMLStrain() {};
-
- protected:
+protected:
   virtual void computeQpProperties() override;
 };
-
-#endif // COMPUTENEMLSTRAIN_H

--- a/include/materials/ComputeNEMLStrainBase.h
+++ b/include/materials/ComputeNEMLStrainBase.h
@@ -1,24 +1,18 @@
-#ifndef COMPUTENEMLSTRAINBASE_H
-#define COMPUTENEMLSTRAINBASE_H
+#pragma once
 
-#include "Material.h"
 #include "DerivativeMaterialInterface.h"
+#include "Material.h"
 
-#include "RankTwoTensor.h"
 #include "RankFourTensor.h"
+#include "RankTwoTensor.h"
 
-class ComputeNEMLStrainBase;
+class ComputeNEMLStrainBase : public DerivativeMaterialInterface<Material> {
+public:
+  static InputParameters validParams();
+  ComputeNEMLStrainBase(const InputParameters &parameters);
+  virtual ~ComputeNEMLStrainBase(){};
 
-template <>
-InputParameters validParams<ComputeNEMLStrainBase>();
-
-class ComputeNEMLStrainBase: public DerivativeMaterialInterface<Material>
-{
- public:
-  ComputeNEMLStrainBase(const InputParameters & parameters);
-  virtual ~ComputeNEMLStrainBase() {};
-
- protected:
+protected:
   virtual void initialSetup() override;
   virtual void initQpStatefulProperties() override;
   virtual void computeProperties() override;
@@ -28,7 +22,7 @@ class ComputeNEMLStrainBase: public DerivativeMaterialInterface<Material>
 
   RankTwoTensor eigenstrainIncrement();
 
- protected:
+protected:
   unsigned int _ndisp;
 
   std::vector<const VariableValue *> _disp;
@@ -36,20 +30,18 @@ class ComputeNEMLStrainBase: public DerivativeMaterialInterface<Material>
   std::vector<const VariableValue *> _disp_old;
   std::vector<const VariableGradient *> _grad_disp_old;
 
-  MaterialProperty<RankTwoTensor> & _strain_inc;
-  MaterialProperty<RankTwoTensor> & _mechanical_strain_inc;
-  MaterialProperty<RankTwoTensor> & _vorticity_inc;
+  MaterialProperty<RankTwoTensor> &_strain_inc;
+  MaterialProperty<RankTwoTensor> &_mechanical_strain_inc;
+  MaterialProperty<RankTwoTensor> &_vorticity_inc;
 
-  MaterialProperty<RankTwoTensor> & _def_grad;
-  const MaterialProperty<RankTwoTensor> & _def_grad_old;
+  MaterialProperty<RankTwoTensor> &_def_grad;
+  const MaterialProperty<RankTwoTensor> &_def_grad_old;
 
-  MaterialProperty<RankTwoTensor> & _df;
+  MaterialProperty<RankTwoTensor> &_df;
 
   std::vector<MaterialPropertyName> _eigenstrain_names;
-  std::vector<const MaterialProperty<RankTwoTensor>*> _eigenstrains;
-  std::vector<const MaterialProperty<RankTwoTensor>*> _eigenstrains_old;
+  std::vector<const MaterialProperty<RankTwoTensor> *> _eigenstrains;
+  std::vector<const MaterialProperty<RankTwoTensor> *> _eigenstrains_old;
 
   bool _ld;
 };
-
-#endif // COMPUTENEMLSTRAINBASE_H

--- a/include/materials/ComputeNEMLStress.h
+++ b/include/materials/ComputeNEMLStress.h
@@ -1,70 +1,61 @@
-#ifndef COMPUTENEMLSTRESS_H
-#define COMPUTENEMLSTRESS_H
+#pragma once
 
-#include "Material.h"
-#include "RankTwoTensor.h"
-#include "RankFourTensor.h"
 #include "DerivativeMaterialInterface.h"
+#include "Material.h"
+#include "RankFourTensor.h"
+#include "RankTwoTensor.h"
 
 #include "neml_interface.h"
 
-class ComputeNEMLStress;
+class ComputeNEMLStress : public DerivativeMaterialInterface<Material> {
+public:
+  static InputParameters validParams();
+  ComputeNEMLStress(const InputParameters &parameters);
 
-template <>
-InputParameters validParams<ComputeNEMLStress>();
-
-class ComputeNEMLStress: public DerivativeMaterialInterface<Material>
-{
- public:
-  ComputeNEMLStress(const InputParameters & parameters);
-
- protected:
+protected:
   virtual void computeQpProperties() override;
   virtual void initQpStatefulProperties() override;
 
- protected:
-  MaterialProperty<RankTwoTensor> & _stress;
-  MaterialProperty<RankTwoTensor> & _elastic_strain;
+protected:
+  MaterialProperty<RankTwoTensor> &_stress;
+  MaterialProperty<RankTwoTensor> &_elastic_strain;
 
-  const MaterialProperty<RankTwoTensor> & _mechanical_strain;  
-  const MaterialProperty<RankTwoTensor> & _extra_stress;
+  const MaterialProperty<RankTwoTensor> &_mechanical_strain;
+  const MaterialProperty<RankTwoTensor> &_extra_stress;
 
-  MaterialProperty<RankFourTensor> & _Jacobian_mult;
+  MaterialProperty<RankFourTensor> &_Jacobian_mult;
 
   FileName _fname;
   std::string _mname;
   std::unique_ptr<neml::NEMLModel> _model;
-  MaterialProperty<std::vector<Real>> & _hist;
-  const MaterialProperty<std::vector<Real>> & _hist_old;
-  const MaterialProperty<RankTwoTensor> & _mechanical_strain_old;
-  const MaterialProperty<RankTwoTensor> & _stress_old;
-  MaterialProperty<Real> & _energy;
-  const MaterialProperty<Real> & _energy_old;
-  MaterialProperty<Real> & _dissipation;
-  const MaterialProperty<Real> & _dissipation_old;
-  const VariableValue & _temperature; // Will default to zero
-  const VariableValue & _temperature_old;
-  MaterialProperty<RankTwoTensor> & _inelastic_strain;
+  MaterialProperty<std::vector<Real>> &_hist;
+  const MaterialProperty<std::vector<Real>> &_hist_old;
+  const MaterialProperty<RankTwoTensor> &_mechanical_strain_old;
+  const MaterialProperty<RankTwoTensor> &_stress_old;
+  MaterialProperty<Real> &_energy;
+  const MaterialProperty<Real> &_energy_old;
+  MaterialProperty<Real> &_dissipation;
+  const MaterialProperty<Real> &_dissipation_old;
+  const VariableValue &_temperature; // Will default to zero
+  const VariableValue &_temperature_old;
+  MaterialProperty<RankTwoTensor> &_inelastic_strain;
 };
 
 /// Tensor -> my notation
-void tensor_neml(const RankTwoTensor & in, double * const out);
+void tensor_neml(const RankTwoTensor &in, double *const out);
 
 /// Vector -> tensor
-void neml_tensor(const double * const in, RankTwoTensor & out);
+void neml_tensor(const double *const in, RankTwoTensor &out);
 
 /// Tangent -> tensor
-void neml_tangent(const double * const in, RankFourTensor & out);
+void neml_tangent(const double *const in, RankFourTensor &out);
 
 /// Tensor -> skew vector
-void tensor_skew(const RankTwoTensor & in, double * const out);
+void tensor_skew(const RankTwoTensor &in, double *const out);
 
 /// Skew vector -> tensor
-void skew_tensor(const double * const in, RankTwoTensor & out);
+void skew_tensor(const double *const in, RankTwoTensor &out);
 
 /// Skew + symmetric parts to full tangent
-void recombine_tangent(const double * const Dpart, 
-                       const double * const Wpart,
-                       RankFourTensor & out);
-
-#endif // COMPUTENEMLSTRESS_H
+void recombine_tangent(const double *const Dpart, const double *const Wpart,
+                       RankFourTensor &out);

--- a/include/materials/ComputeNEMLStressBase.h
+++ b/include/materials/ComputeNEMLStressBase.h
@@ -1,76 +1,67 @@
-#ifndef COMPUTENEMLSTRESSBASE_H
-#define COMPUTENEMLSTRESSBASE_H
+#pragma once
 
-#include "Material.h"
-#include "DerivativeMaterialInterface.h"
-#include "RankTwoTensor.h"
-#include "RankFourTensor.h"
 #include "ComputeNEMLStress.h"
+#include "DerivativeMaterialInterface.h"
+#include "Material.h"
+#include "RankFourTensor.h"
+#include "RankTwoTensor.h"
 
 #include "neml_interface.h"
 
-class ComputeNEMLStressBase;
+class ComputeNEMLStressBase : public DerivativeMaterialInterface<Material> {
+public:
+  static InputParameters validParams();
+  ComputeNEMLStressBase(const InputParameters &parameters);
+  virtual ~ComputeNEMLStressBase(){};
 
-template <>
-InputParameters validParams<ComputeNEMLStressBase>();
-
-class ComputeNEMLStressBase: public DerivativeMaterialInterface<Material>
-{
- public:
-  ComputeNEMLStressBase(const InputParameters & parameters);
-  virtual ~ComputeNEMLStressBase() {};
-
- protected:
+protected:
   virtual void computeQpProperties() override;
   virtual void initQpStatefulProperties() override;
 
-  virtual void stressUpdate(
-      const double * const e_np1, const double * const e_n,
-      const double * const w_np1, const double * const w_n,
-      double T_np1, double T_n, double t_np1, double t_n,
-      double * const s_np1, const double * const s_n,
-      double * const h_np1, const double * const h_n,
-      double * const A_np1, double * const B_np1,
-      double & u_np1, double u_n, double & p_np1, double p_n) = 0;
-  
- private:
+  virtual void stressUpdate(const double *const e_np1, const double *const e_n,
+                            const double *const w_np1, const double *const w_n,
+                            double T_np1, double T_n, double t_np1, double t_n,
+                            double *const s_np1, const double *const s_n,
+                            double *const h_np1, const double *const h_n,
+                            double *const A_np1, double *const B_np1,
+                            double &u_np1, double u_n, double &p_np1,
+                            double p_n) = 0;
+
+private:
   void updateStrain();
 
- protected:
+protected:
   FileName _fname;
   std::string _mname;
   std::unique_ptr<neml::NEMLModel> _model;
 
-  const MaterialProperty<RankTwoTensor> & _mechanical_strain_inc;
-  const MaterialProperty<RankTwoTensor> & _vorticity_inc;  
+  const MaterialProperty<RankTwoTensor> &_mechanical_strain_inc;
+  const MaterialProperty<RankTwoTensor> &_vorticity_inc;
 
-  const VariableValue & _temperature; // Will default to zero
-  const VariableValue & _temperature_old;
+  const VariableValue &_temperature; // Will default to zero
+  const VariableValue &_temperature_old;
 
-  MaterialProperty<RankTwoTensor> & _mechanical_strain;  
-  const MaterialProperty<RankTwoTensor> & _mechanical_strain_old;
+  MaterialProperty<RankTwoTensor> &_mechanical_strain;
+  const MaterialProperty<RankTwoTensor> &_mechanical_strain_old;
 
-  MaterialProperty<RankTwoTensor> & _linear_rot;  
-  const MaterialProperty<RankTwoTensor> & _linear_rot_old;
+  MaterialProperty<RankTwoTensor> &_linear_rot;
+  const MaterialProperty<RankTwoTensor> &_linear_rot_old;
 
-  MaterialProperty<RankTwoTensor> & _stress;
-  const MaterialProperty<RankTwoTensor> & _stress_old;
+  MaterialProperty<RankTwoTensor> &_stress;
+  const MaterialProperty<RankTwoTensor> &_stress_old;
 
-  MaterialProperty<RankFourTensor> & _material_jacobian;
+  MaterialProperty<RankFourTensor> &_material_jacobian;
 
-  MaterialProperty<std::vector<Real>> & _hist;
-  const MaterialProperty<std::vector<Real>> & _hist_old;
+  MaterialProperty<std::vector<Real>> &_hist;
+  const MaterialProperty<std::vector<Real>> &_hist_old;
 
-  MaterialProperty<Real> & _energy;
-  const MaterialProperty<Real> & _energy_old;
-  MaterialProperty<Real> & _dissipation;
-  const MaterialProperty<Real> & _dissipation_old;
+  MaterialProperty<Real> &_energy;
+  const MaterialProperty<Real> &_energy_old;
+  MaterialProperty<Real> &_dissipation;
+  const MaterialProperty<Real> &_dissipation_old;
 
-  MaterialProperty<RankTwoTensor> & _elastic_strain;
-  MaterialProperty<RankTwoTensor> & _inelastic_strain;
+  MaterialProperty<RankTwoTensor> &_elastic_strain;
+  MaterialProperty<RankTwoTensor> &_inelastic_strain;
 
   const bool _ld;
 };
-
-
-#endif // COMPUTENEMLSTRESSBASE_H

--- a/include/materials/ComputeNEMLStressUpdate.h
+++ b/include/materials/ComputeNEMLStressUpdate.h
@@ -1,29 +1,20 @@
-#ifndef COMPUTENEMLSTRESSUPDATE_H
-#define COMPUTENEMLSTRESSUPDATE_H
+#pragma once
 
 #include "ComputeNEMLStressBase.h"
 
-class ComputeNEMLStressUpdate;
+class ComputeNEMLStressUpdate : public ComputeNEMLStressBase {
+public:
+  static InputParameters validParams();
+  ComputeNEMLStressUpdate(const InputParameters &parameters);
+  virtual ~ComputeNEMLStressUpdate(){};
 
-template <>
-InputParameters validParams<ComputeNEMLStressUpdate>();
-
-class ComputeNEMLStressUpdate: public ComputeNEMLStressBase
-{
- public:
-  ComputeNEMLStressUpdate(const InputParameters & parameters);
-  virtual ~ComputeNEMLStressUpdate() {};
-
- protected:
-  virtual void stressUpdate(
-      const double * const e_np1, const double * const e_n,
-      const double * const w_np1, const double * const w_n,
-      double T_np1, double T_n, double t_np1, double t_n,
-      double * const s_np1, const double * const s_n,
-      double * const h_np1, const double * const h_n,
-      double * const A_np1, double * const B_np1,
-      double & u_np1, double u_n, double & p_np1, double p_n);
-
+protected:
+  virtual void stressUpdate(const double *const e_np1, const double *const e_n,
+                            const double *const w_np1, const double *const w_n,
+                            double T_np1, double T_n, double t_np1, double t_n,
+                            double *const s_np1, const double *const s_n,
+                            double *const h_np1, const double *const h_n,
+                            double *const A_np1, double *const B_np1,
+                            double &u_np1, double u_n, double &p_np1,
+                            double p_n);
 };
-
-#endif // COMPUTENEMLSTRESSUPDATE_H

--- a/include/materials/ComputeRadiationSwellingEigenstrain.h
+++ b/include/materials/ComputeRadiationSwellingEigenstrain.h
@@ -1,12 +1,6 @@
-#ifndef COMPUTERADIATIONSWELLINGEIGENSTRAIN_H
-#define COMPUTERADIATIONSWELLINGEIGENSTRAIN_H
+#pragma once
 
 #include "ComputeEigenstrainBase.h"
-
-class ComputeRadiationSwellingEigenstrain;
-
-template <>
-InputParameters validParams<ComputeRadiationSwellingEigenstrain>();
 
 /**
  *  Calculate an eigenstrain based on two functions:
@@ -17,19 +11,16 @@ InputParameters validParams<ComputeRadiationSwellingEigenstrain>();
  *  change in volume / volume and the class takes care of the conversion
  *  to strain
  */
-class ComputeRadiationSwellingEigenstrain: public ComputeEigenstrainBase
-{
- public:
-  ComputeRadiationSwellingEigenstrain(const InputParameters & parameters);
+class ComputeRadiationSwellingEigenstrain : public ComputeEigenstrainBase {
+public:
+  static InputParameters validParams();
+  ComputeRadiationSwellingEigenstrain(const InputParameters &parameters);
   virtual void initQpStatefulProperties() override;
   virtual void computeQpEigenstrain() override;
 
- private:
-  const Function & _swelling;
-  const Function & _dose_rate;
-  MaterialProperty<Real> & _dose;
-  const MaterialProperty<Real> & _dose_old;
+private:
+  const Function &_swelling;
+  const Function &_dose_rate;
+  MaterialProperty<Real> &_dose;
+  const MaterialProperty<Real> &_dose_old;
 };
-
-
-#endif

--- a/include/materials/ComputeThermalExpansionEigenstrainNEML.h
+++ b/include/materials/ComputeThermalExpansionEigenstrainNEML.h
@@ -1,48 +1,31 @@
-#ifndef COMPUTETHERMALEXPANSIONEIGENSTRAINNEML_H
-#define COMPUTETHERMALEXPANSIONEIGENSTRAINNEML_H
+#pragma once
 
 #include "ComputeThermalExpansionEigenstrainBase.h"
 
 #include "neml_interface.h"
 
-class ComputeThermalExpansionEigenstrainNEML;
-
-template <>
-InputParameters validParams<ComputeThermalExpansionEigenstrainNEML>();
-
 /**
  *  ComputeThermalExpansionEigenstrainNEML computes the thermal expansion
  *  strain from the instantaneous CTE provided by a NEML model
  */
-class ComputeThermalExpansionEigenstrainNEML: public ComputeThermalExpansionEigenstrainBase
-{
- public:
-  ComputeThermalExpansionEigenstrainNEML(const InputParameters & parameters);
+class ComputeThermalExpansionEigenstrainNEML
+    : public ComputeThermalExpansionEigenstrainBase {
+public:
+  static InputParameters validParams();
+  ComputeThermalExpansionEigenstrainNEML(const InputParameters &parameters);
   virtual void initQpStatefulProperties() override;
 
- protected:
-  virtual void computeThermalStrain(Real & thermal_strain, Real & instantaneous_cte) override;
+protected:
+  virtual void computeThermalStrain(Real &thermal_strain,
+                                    Real &instantaneous_cte) override;
 
- protected:
+protected:
   FileName _fname;
   std::string _mname;
   std::unique_ptr<neml::NEMLModel> _model;
 
-  MaterialProperty<Real> & _tstrain;
-  const MaterialProperty<Real> & _tstrain_old;
+  MaterialProperty<Real> &_tstrain;
+  const MaterialProperty<Real> &_tstrain_old;
 
-  const VariableValue & _temperature_old;
+  const VariableValue &_temperature_old;
 };
-
-
-
-
-
-
-
-
-
-
-
-
-#endif // COMPUTETHERMALEXPANSIONEIGENSTRAINNEML_H

--- a/src/actions/NEMLMechanicsAction.C
+++ b/src/actions/NEMLMechanicsAction.C
@@ -19,8 +19,8 @@ const std::map<std::pair<int, int>, std::string> tensor_map = {
     {std::make_pair(2, 2), "z-z"}, {std::make_pair(0, 1), "x-y"},
     {std::make_pair(0, 2), "x-z"}, {std::make_pair(1, 2), "y-z"}};
 
-template <> InputParameters validParams<NEMLMechanicsAction>() {
-  InputParameters params = validParams<Action>();
+InputParameters NEMLMechanicsAction::validParams() {
+  InputParameters params = Action::validParams();
 
   params.addRequiredParam<std::vector<VariableName>>(
       "displacements", "The displacement variables");
@@ -38,9 +38,9 @@ template <> InputParameters validParams<NEMLMechanicsAction>() {
       "add_all_output", false,
       "Dump all the usual stress and strain variables to the output");
 
-  params.addParam<std::vector<MaterialPropertyName>>("eigenstrains",
-                                                     std::vector<MaterialPropertyName>(),
-                                                     "Names of the eigenstrains");
+  params.addParam<std::vector<MaterialPropertyName>>(
+      "eigenstrains", std::vector<MaterialPropertyName>(),
+      "Names of the eigenstrains");
 
   return params;
 }
@@ -52,10 +52,8 @@ NEMLMechanicsAction::NEMLMechanicsAction(const InputParameters &params)
       _add_disp(getParam<bool>("add_displacements")),
       _add_all(getParam<bool>("add_all_output")),
       _kinematics(getParam<MooseEnum>("kinematics").getEnum<Kinematics>()),
-      _eigenstrains(getParam<std::vector<MaterialPropertyName>>("eigenstrains"))
-{
-
-}
+      _eigenstrains(
+          getParam<std::vector<MaterialPropertyName>>("eigenstrains")) {}
 
 void NEMLMechanicsAction::act() {
   if (_current_task == "add_variable") {
@@ -78,7 +76,8 @@ void NEMLMechanicsAction::act() {
     auto params = _factory.getValidParams("ComputeNEMLStrain");
 
     params.set<std::vector<VariableName>>("displacements") = _displacements;
-    params.set<std::vector<MaterialPropertyName>>("eigenstrain_names") = _eigenstrains;
+    params.set<std::vector<MaterialPropertyName>>("eigenstrain_names") =
+        _eigenstrains;
     params.set<bool>("large_kinematics") = _kin_mapper[_kinematics];
 
     _problem->addMaterial("ComputeNEMLStrain", "strain", params);

--- a/src/auxkernels/TimeDerivAuxKernel.C
+++ b/src/auxkernels/TimeDerivAuxKernel.C
@@ -2,25 +2,17 @@
 
 registerMooseObject("DeerApp", TimeDerivAuxKernel);
 
-template <>
-InputParameters
-validParams<TimeDerivAuxKernel>()
-{
-  InputParameters params = validParams<AuxKernel>();
+InputParameters TimeDerivAuxKernel::validParams() {
+  InputParameters params = AuxKernel::validParams();
   params.addRequiredCoupledVar("coupled", "Coupled variable");
 
   return params;
 }
 
-TimeDerivAuxKernel::TimeDerivAuxKernel(const InputParameters & parameters) :
-    AuxKernel(parameters), _coupled_new(coupledValue("coupled")),
-    _coupled_old(coupledValueOld("coupled"))
-{
+TimeDerivAuxKernel::TimeDerivAuxKernel(const InputParameters &parameters)
+    : AuxKernel(parameters), _coupled_new(coupledValue("coupled")),
+      _coupled_old(coupledValueOld("coupled")) {}
 
-}
-
-Real
-TimeDerivAuxKernel::computeValue()
-{
+Real TimeDerivAuxKernel::computeValue() {
   return (_coupled_new[_qp] - _coupled_old[_qp]) / _dt;
 }

--- a/src/auxkernels/TractionAux.C
+++ b/src/auxkernels/TractionAux.C
@@ -16,13 +16,14 @@
 
 registerMooseObject("DeerApp", TractionAux);
 
-MooseEnum traction_component() {
+MooseEnum TractionAux::traction_component() {
   return MooseEnum("normal shear1 shear2 shear_norm");
 }
 
-template <> InputParameters validParams<TractionAux>() {
-  InputParameters params = validParams<MaterialAuxBase<>>();
-  params.addRequiredParam<MooseEnum>("scalar_type", traction_component(),
+InputParameters TractionAux::validParams() {
+  InputParameters params = MaterialAuxBase<RankTwoTensor>::validParams();
+  params.addRequiredParam<MooseEnum>("scalar_type",
+                                     TractionAux::traction_component(),
                                      "Type of scalar output");
 
   params.addClassDescription("Compute traction components on a boundary and "

--- a/src/base/DeerApp.C
+++ b/src/base/DeerApp.C
@@ -1,67 +1,48 @@
-#include "DeerApp.h"
-#include "Moose.h"
 #include "AppFactory.h"
+#include "DeerApp.h"
 #include "ModulesApp.h"
+#include "Moose.h"
 #include "MooseSyntax.h"
 
 // New functions
-#include "ThicknessGradient.h"
 #include "CapGradient.h"
+#include "ThicknessGradient.h"
 
 // New materials
 #include "ComputeNEMLStress.h"
-#include "ComputeThermalExpansionEigenstrainNEML.h"
 #include "ComputeRadiationSwellingEigenstrain.h"
+#include "ComputeThermalExpansionEigenstrainNEML.h"
 
-template<>
-InputParameters validParams<DeerApp>()
-{
-  InputParameters params = validParams<MooseApp>();
+InputParameters DeerApp::validParams() {
+  InputParameters params = MooseApp::validParams();
   return params;
 }
 
-DeerApp::DeerApp(InputParameters parameters) :
-    MooseApp(parameters)
-{
+DeerApp::DeerApp(InputParameters parameters) : MooseApp(parameters) {
   DeerApp::registerAll(_factory, _action_factory, _syntax);
 }
 
-DeerApp::~DeerApp()
-{
-}
+DeerApp::~DeerApp() {}
 
-static void
-associateSyntaxInner(Syntax & syntax, ActionFactory & /*action_factory*/)
-{
+static void associateSyntaxInner(Syntax &syntax,
+                                 ActionFactory & /*action_factory*/) {
   registerSyntax("NEMLMechanicsAction", "NEMLMechanics");
 }
 
-void
-DeerApp::registerApps()
-{
-  registerApp(DeerApp);
-}
+void DeerApp::registerApps() { registerApp(DeerApp); }
 
-void
-DeerApp::registerAll(Factory & f, ActionFactory & af, Syntax & s)
-{
+void DeerApp::registerAll(Factory &f, ActionFactory &af, Syntax &s) {
   Registry::registerObjectsTo(f, {"DeerApp"});
   Registry::registerActionsTo(af, {"DeerApp"});
-  
+
   associateSyntaxInner(s, af);
 
   ModulesApp::registerAll(f, af, s);
 }
 
 // External entry point for dynamic application loading
-extern "C" void
-DeerApp__registerApps()
-{
-  DeerApp::registerApps();
-}
+extern "C" void DeerApp__registerApps() { DeerApp::registerApps(); }
 
-extern "C" void
-DeepApp__registerAll(Factory & f, ActionFactory &af, Syntax & s)
-{
+extern "C" void DeepApp__registerAll(Factory &f, ActionFactory &af, Syntax &s) {
   DeerApp::registerAll(f, af, s);
 }

--- a/src/functions/CapGradient.C
+++ b/src/functions/CapGradient.C
@@ -2,11 +2,8 @@
 
 registerMooseObject("DeerApp", CapGradient);
 
-template <>
-InputParameters
-validParams<CapGradient>()
-{
-  InputParameters params = validParams<Function>();
+InputParameters CapGradient::validParams() {
+  InputParameters params = Function::validParams();
   params.addParam<Real>("delay", 0.0, "Keep T1 until...");
   params.addParam<Real>("T1", 0.0, "Initial temperature");
   params.addParam<Real>("T2", 0.0, "Peak temperature");
@@ -23,22 +20,16 @@ validParams<CapGradient>()
   return params;
 }
 
-CapGradient::CapGradient(const InputParameters & parameters) 
-  : Function(parameters), _delay(getParam<Real>("delay")), 
-    _T1(getParam<Real>("T1")), _T2(getParam<Real>("T2")), 
-    _tramp1(getParam<Real>("tramp1")), _thold1(getParam<Real>("thold1")),
-    _tramp2(getParam<Real>("tramp2")), _thold2(getParam<Real>("thold2")),
-    _r1(getParam<Real>("r1")),
-    _r2(getParam<Real>("r2")), 
-    _trans(getParam<Real>("trans")), _radius(getParam<Real>("radius")),
-    _index(getParam<int>("index"))
-{
+CapGradient::CapGradient(const InputParameters &parameters)
+    : Function(parameters), _delay(getParam<Real>("delay")),
+      _T1(getParam<Real>("T1")), _T2(getParam<Real>("T2")),
+      _tramp1(getParam<Real>("tramp1")), _thold1(getParam<Real>("thold1")),
+      _tramp2(getParam<Real>("tramp2")), _thold2(getParam<Real>("thold2")),
+      _r1(getParam<Real>("r1")), _r2(getParam<Real>("r2")),
+      _trans(getParam<Real>("trans")), _radius(getParam<Real>("radius")),
+      _index(getParam<int>("index")) {}
 
-}
-
-Real
-CapGradient::value(Real t, const Point & p)
-{
+Real CapGradient::value(Real t, const Point &p) {
   // This trusts that z = 0.0 for 2d meshes...
   double z;
   int oc[2];
@@ -46,30 +37,28 @@ CapGradient::value(Real t, const Point & p)
     z = p(0);
     oc[0] = 1;
     oc[1] = 2;
-  }
-  else if (_index == 1) {
+  } else if (_index == 1) {
     z = p(1);
     oc[0] = 0;
     oc[1] = 2;
-  }
-  else if (_index == 2) {
+  } else if (_index == 2) {
     z = p(2);
     oc[0] = 0;
     oc[1] = 1;
-  }
-  else {
+  } else {
     mooseError("Coordinate index provided is > 2!");
   }
-  
+
   double r;
   if (z < _trans) {
     r = 0.0;
-    for (int i=0; i<2; i++) r += p(oc[i]) * p(oc[i]);
+    for (int i = 0; i < 2; i++)
+      r += p(oc[i]) * p(oc[i]);
     r = sqrt(r);
-  }
-  else {
+  } else {
     r = 0.0;
-    for (int i=0; i<2; i++) r += p(oc[i]) * p(oc[i]);
+    for (int i = 0; i < 2; i++)
+      r += p(oc[i]) * p(oc[i]);
     r += pow(p(_index) - _trans, 2.0);
     r = sqrt(r);
   }
@@ -83,26 +72,18 @@ CapGradient::value(Real t, const Point & p)
     Real T2p;
     if (nt < _tramp1) {
       T2p = _T1 + (_T2 - _T1) / _tramp1 * nt;
-    }
-    else if (nt < (_tramp1 + _thold1)) {
+    } else if (nt < (_tramp1 + _thold1)) {
       T2p = _T2;
-    }
-    else if (nt < (_tramp1 + _thold1 + _tramp2)) {
+    } else if (nt < (_tramp1 + _thold1 + _tramp2)) {
       T2p = _T2 + (_T1 - _T2) / _tramp2 * (nt - _tramp1 - _thold1);
-    }
-    else {
+    } else {
       T2p = _T1;
     }
 
     return _getTemp(T2p, nx);
-  }
-  else {
+  } else {
     return _T1;
   }
 }
 
-Real
-CapGradient::_getTemp(Real T2p, Real nx)
-{
-  return (T2p - _T1) * nx + _T1;
-}
+Real CapGradient::_getTemp(Real T2p, Real nx) { return (T2p - _T1) * nx + _T1; }

--- a/src/functions/CycleFraction.C
+++ b/src/functions/CycleFraction.C
@@ -13,8 +13,8 @@
 
 registerMooseObject("DeerApp", CycleFraction);
 
-template <> InputParameters validParams<CycleFraction>() {
-  InputParameters params = validParams<Function>();
+InputParameters CycleFraction::validParams() {
+  InputParameters params = Function::validParams();
   params.addRequiredParam<Real>("cycle_period", "period of the cycle");
   params.addClassDescription("Function providing the cycle fraction given "
                              "simulation time and cycle period");

--- a/src/functions/CycleNumber.C
+++ b/src/functions/CycleNumber.C
@@ -13,8 +13,8 @@
 
 registerMooseObject("DeerApp", CycleNumber);
 
-template <> InputParameters validParams<CycleNumber>() {
-  InputParameters params = validParams<Function>();
+InputParameters CycleNumber::validParams() {
+  InputParameters params = Function::validParams();
   params.addRequiredParam<Real>("cycle_period", "period of the cycle");
   params.addClassDescription("Function providing the cycle number given "
                              "simulation time and cycle period");

--- a/src/functions/CycleTime.C
+++ b/src/functions/CycleTime.C
@@ -13,8 +13,8 @@
 
 registerMooseObject("DeerApp", CycleTime);
 
-template <> InputParameters validParams<CycleTime>() {
-  InputParameters params = validParams<Function>();
+InputParameters CycleTime::validParams() {
+  InputParameters params = Function::validParams();
   params.addRequiredParam<Real>("cycle_period", "period of the cycle");
   params.addClassDescription("Function providing the cycle time given "
                              "simulation time and cycle period");

--- a/src/functions/PiecewiseLinearCycle.C
+++ b/src/functions/PiecewiseLinearCycle.C
@@ -11,8 +11,8 @@
 
 registerMooseObject("DeerApp", PiecewiseLinearCycle);
 
-template <> InputParameters validParams<PiecewiseLinearCycle>() {
-  InputParameters params = validParams<PiecewiseLinear>();
+InputParameters PiecewiseLinearCycle::validParams() {
+  InputParameters params = PiecewiseLinear::validParams();
   params.addRequiredParam<FunctionName>("cycle_time_func",
                                         "The CycleTime function name");
   params.addClassDescription("linearly interpolate a function cyclicly");

--- a/src/functions/ThicknessGradient.C
+++ b/src/functions/ThicknessGradient.C
@@ -2,11 +2,8 @@
 
 registerMooseObject("DeerApp", ThicknessGradient);
 
-template <>
-InputParameters
-validParams<ThicknessGradient>()
-{
-  InputParameters params = validParams<Function>();
+InputParameters ThicknessGradient::validParams() {
+  InputParameters params = Function::validParams();
   params.addParam<Real>("delay", 0.0, "Keep T1 until...");
   params.addParam<Real>("T1", 0.0, "Initial temperature");
   params.addParam<Real>("T2", 0.0, "Peak temperature");
@@ -21,20 +18,15 @@ validParams<ThicknessGradient>()
   return params;
 }
 
-ThicknessGradient::ThicknessGradient(const InputParameters & parameters) 
-  : Function(parameters), _delay(getParam<Real>("delay")), 
-    _T1(getParam<Real>("T1")), _T2(getParam<Real>("T2")), 
-    _tramp1(getParam<Real>("tramp1")), _thold1(getParam<Real>("thold1")),
-    _tramp2(getParam<Real>("tramp2")), _thold2(getParam<Real>("thold2")),
-    _x1(getParam<Real>("x1")),
-    _x2(getParam<Real>("x2")), _index(getParam<int>("index"))
-{
+ThicknessGradient::ThicknessGradient(const InputParameters &parameters)
+    : Function(parameters), _delay(getParam<Real>("delay")),
+      _T1(getParam<Real>("T1")), _T2(getParam<Real>("T2")),
+      _tramp1(getParam<Real>("tramp1")), _thold1(getParam<Real>("thold1")),
+      _tramp2(getParam<Real>("tramp2")), _thold2(getParam<Real>("thold2")),
+      _x1(getParam<Real>("x1")), _x2(getParam<Real>("x2")),
+      _index(getParam<int>("index")) {}
 
-}
-
-Real
-ThicknessGradient::value(Real t, const Point & p)
-{
+Real ThicknessGradient::value(Real t, const Point &p) {
   Real x = p(_index);
   Real period = _tramp1 + _thold1 + _tramp2 + _thold2;
 
@@ -45,26 +37,20 @@ ThicknessGradient::value(Real t, const Point & p)
     Real T2p;
     if (nt < _tramp1) {
       T2p = _T1 + (_T2 - _T1) / _tramp1 * nt;
-    }
-    else if (nt < (_tramp1 + _thold1)) {
+    } else if (nt < (_tramp1 + _thold1)) {
       T2p = _T2;
-    }
-    else if (nt < (_tramp1 + _thold1 + _tramp2)) {
+    } else if (nt < (_tramp1 + _thold1 + _tramp2)) {
       T2p = _T2 + (_T1 - _T2) / _tramp2 * (nt - _tramp1 - _thold1);
-    }
-    else {
+    } else {
       T2p = _T1;
     }
 
     return _getTemp(T2p, nx);
-  }
-  else {
+  } else {
     return _T1;
   }
 }
 
-Real
-ThicknessGradient::_getTemp(Real T2p, Real nx)
-{
+Real ThicknessGradient::_getTemp(Real T2p, Real nx) {
   return (T2p - _T1) * nx + _T1;
 }

--- a/src/kernels/StressDivergenceNEML.C
+++ b/src/kernels/StressDivergenceNEML.C
@@ -2,37 +2,29 @@
 
 registerMooseObject("DeerApp", StressDivergenceNEML);
 
-template <>
-InputParameters
-validParams<StressDivergenceNEML>()
-{
-  InputParameters params = validParams<Kernel>();
+InputParameters StressDivergenceNEML::validParams() {
+  InputParameters params = Kernel::validParams();
 
-  params.addRequiredParam<unsigned int>("component", 
+  params.addRequiredParam<unsigned int>("component",
                                         "Which direction this kernel acts in");
-  params.addRequiredCoupledVar("displacements",
-                               "The displacement components");
+  params.addRequiredCoupledVar("displacements", "The displacement components");
   return params;
 }
 
-StressDivergenceNEML::StressDivergenceNEML(const InputParameters & parameters) 
-  : DerivativeMaterialInterface<Kernel>(parameters),
-    _ld(getParam<bool>("use_displaced_mesh")),
-    _component(getParam<unsigned int>("component")),
-    _ndisp(coupledComponents("displacements")),
-    _disp_nums(_ndisp),
-    _disp_vars(_ndisp),
-    _grad_disp(_ndisp),
-    _stress(getMaterialPropertyByName<RankTwoTensor>("stress")),
-    _material_jacobian(getMaterialPropertyByName<RankFourTensor>("material_jacobian")),
-    _df(getMaterialPropertyByName<RankTwoTensor>("df"))
+StressDivergenceNEML::StressDivergenceNEML(const InputParameters &parameters)
+    : DerivativeMaterialInterface<Kernel>(parameters),
+      _ld(getParam<bool>("use_displaced_mesh")),
+      _component(getParam<unsigned int>("component")),
+      _ndisp(coupledComponents("displacements")), _disp_nums(_ndisp),
+      _disp_vars(_ndisp), _grad_disp(_ndisp),
+      _stress(getMaterialPropertyByName<RankTwoTensor>("stress")),
+      _material_jacobian(
+          getMaterialPropertyByName<RankFourTensor>("material_jacobian")),
+      _df(getMaterialPropertyByName<RankTwoTensor>("df"))
 
-{
+{}
 
-}
-
-void StressDivergenceNEML::initialSetup()
-{
+void StressDivergenceNEML::initialSetup() {
   for (unsigned int i = 0; i < _ndisp; i++) {
     _disp_nums[i] = coupled("displacements", i);
     _disp_vars[i] = getVar("displacements", i);
@@ -40,60 +32,43 @@ void StressDivergenceNEML::initialSetup()
   }
 }
 
-void StressDivergenceNEML::precalculateResidual()
-{
+void StressDivergenceNEML::precalculateResidual() {}
 
-}
+void StressDivergenceNEML::precalculateJacobian() {}
 
-void StressDivergenceNEML::precalculateJacobian()
-{
+void StressDivergenceNEML::precalculateOffDiagJacobian(unsigned int jvar) {}
 
-}
-
-void StressDivergenceNEML::precalculateOffDiagJacobian(unsigned int jvar)
-{
-
-}
-
-Real StressDivergenceNEML::computeQpResidual()
-{
+Real StressDivergenceNEML::computeQpResidual() {
   return _stress[_qp].row(_component) * _grad_test[_i][_qp];
 }
 
-Real StressDivergenceNEML::computeQpJacobian()
-{
+Real StressDivergenceNEML::computeQpJacobian() {
   Real value = 0.0;
 
-  value += matJacobianComponent(_material_jacobian[_qp],
-                                _component, _component,
-                                _grad_test[_i][_qp], _grad_phi[_j][_qp],
-                                _df[_qp]);
+  value +=
+      matJacobianComponent(_material_jacobian[_qp], _component, _component,
+                           _grad_test[_i][_qp], _grad_phi[_j][_qp], _df[_qp]);
 
   if (_ld) {
-    value += geomJacobianComponent(_component, _component,
-                                   _grad_test[_i][_qp], _grad_phi[_j][_qp],
-                                   _stress[_qp]);
+    value += geomJacobianComponent(_component, _component, _grad_test[_i][_qp],
+                                   _grad_phi[_j][_qp], _stress[_qp]);
   }
-  
+
   return value;
 }
 
-Real StressDivergenceNEML::computeQpOffDiagJacobian(unsigned int jvar)
-{
+Real StressDivergenceNEML::computeQpOffDiagJacobian(unsigned int jvar) {
   Real value = 0.0;
-  
+
   for (unsigned int cc = 0; cc < _ndisp; cc++) {
     if (jvar == _disp_nums[cc]) {
-      value += matJacobianComponent(_material_jacobian[_qp],
-                              _component, cc,
-                              _grad_test[_i][_qp], 
-                              _disp_vars[cc]->gradPhi()[_j][_qp],
-                              _df[_qp]);
+      value += matJacobianComponent(
+          _material_jacobian[_qp], _component, cc, _grad_test[_i][_qp],
+          _disp_vars[cc]->gradPhi()[_j][_qp], _df[_qp]);
       if (_ld) {
-        value += geomJacobianComponent(_component, cc,
-                                       _grad_test[_i][_qp],
+        value += geomJacobianComponent(_component, cc, _grad_test[_i][_qp],
                                        _disp_vars[cc]->gradPhi()[_j][_qp],
-                                       _stress[_qp]); 
+                                       _stress[_qp]);
       }
       break;
     }
@@ -102,19 +77,17 @@ Real StressDivergenceNEML::computeQpOffDiagJacobian(unsigned int jvar)
   return value;
 }
 
-Real StressDivergenceNEML::matJacobianComponent(
-    const RankFourTensor & C,
-    unsigned int i, unsigned int m,
-    const RealGradient & grad_psi,
-    const RealGradient & grad_phi,
-    const RankTwoTensor & df)
-{
+Real StressDivergenceNEML::matJacobianComponent(const RankFourTensor &C,
+                                                unsigned int i, unsigned int m,
+                                                const RealGradient &grad_psi,
+                                                const RealGradient &grad_phi,
+                                                const RankTwoTensor &df) {
   Real value = 0.0;
 
-  for (int j=0; j<_ndisp; j++) {
-    for (int k=0; k<_ndisp; k++) {
-      for (int l =0; l<_ndisp; l++) {
-        value += C(i,j,k,l) * grad_psi(j) * df(k,m) * grad_phi(l);
+  for (int j = 0; j < _ndisp; j++) {
+    for (int k = 0; k < _ndisp; k++) {
+      for (int l = 0; l < _ndisp; l++) {
+        value += C(i, j, k, l) * grad_psi(j) * df(k, m) * grad_phi(l);
       }
     }
   }
@@ -122,18 +95,16 @@ Real StressDivergenceNEML::matJacobianComponent(
   return value;
 }
 
-Real StressDivergenceNEML::geomJacobianComponent(
-    unsigned int i, unsigned int m,
-    const RealGradient & grad_psi,
-    const RealGradient & grad_phi,
-    const RankTwoTensor & stress)
-{
+Real StressDivergenceNEML::geomJacobianComponent(unsigned int i, unsigned int m,
+                                                 const RealGradient &grad_psi,
+                                                 const RealGradient &grad_phi,
+                                                 const RankTwoTensor &stress) {
 
   Real value = 0.0;
-  
-  for (int k=0; k<_ndisp; k++) {
-    value += stress(i,k) * grad_psi(k) * grad_phi(m);
-    value -= stress(i,k) * grad_phi(k) * grad_psi(m);
+
+  for (int k = 0; k < _ndisp; k++) {
+    value += stress(i, k) * grad_psi(k) * grad_phi(m);
+    value -= stress(i, k) * grad_phi(k) * grad_psi(m);
   }
 
   return value;

--- a/src/materials/ComputeNEMLCPOutput.C
+++ b/src/materials/ComputeNEMLCPOutput.C
@@ -2,79 +2,75 @@
 
 registerMooseObject("DeerApp", ComputeNEMLCPOutput);
 
-template <>
-InputParameters
-validParams<ComputeNEMLCPOutput>()
-{
-  InputParameters params = validParams<ComputeNEMLStressUpdate>();
-  params.addParam<UserObjectName>("euler_angle_provider","dummy"
-                                        "Name of Euelr angle provider user object");
-  params.addParam<unsigned int>("grain_id", 0,"ID of the grain for this material");
+InputParameters ComputeNEMLCPOutput::validParams() {
+  InputParameters params = ComputeNEMLStressUpdate::validParams();
+  params.addParam<UserObjectName>("euler_angle_provider",
+                                  "dummy"
+                                  "Name of Euelr angle provider user object");
+  params.addParam<unsigned int>("grain_id", 0,
+                                "ID of the grain for this material");
   return params;
 }
 
-ComputeNEMLCPOutput::ComputeNEMLCPOutput(const InputParameters & parameters)
-   : ComputeNEMLStressUpdate(parameters),
-    _orientation_q(declareProperty<std::vector<Real>>("orientation_q")),
-    _euler(parameters.isParamSetByUser("euler_angle_provider") ? &getUserObject<EulerAngleProvider>("euler_angle_provider") : nullptr), // May be making it a required parameter
-    _grain(getParam<unsigned int>("grain_id"))
-{
+ComputeNEMLCPOutput::ComputeNEMLCPOutput(const InputParameters &parameters)
+    : ComputeNEMLStressUpdate(parameters),
+      _orientation_q(declareProperty<std::vector<Real>>("orientation_q")),
+      _euler(parameters.isParamSetByUser("euler_angle_provider")
+                 ? &getUserObject<EulerAngleProvider>("euler_angle_provider")
+                 : nullptr), // May be making it a required parameter
+      _grain(getParam<unsigned int>("grain_id")) {
   _cpmodel = static_cast<neml::SingleCrystalModel *>(_model.get());
 
-  if(!parameters.isParamSetByUser("grain_id")){
+  if (!parameters.isParamSetByUser("grain_id")) {
     mooseWarning("grain id's not provided, block id will be used for the cp");
     _given = 0;
-   }
+  }
 
-  if(_euler == nullptr ) {
-    mooseWarning("no euler angle file is given for a single default orientation will be used !!!!");
-   }
- }
-
-// Assigning Euler angles from file
-void
-ComputeNEMLCPOutput::initQpStatefulProperties()
-{
-  ComputeNEMLStressBase::initQpStatefulProperties();
-  if (_euler != nullptr) {
-      EulerAngles angles;
-      if (_given == 0){
-        unsigned int grain = std::max(_current_elem->subdomain_id() - 1,0); // to avoid block 0 condition
-        angles = _euler->getEulerAngles(grain); // current orientation
-      }
-      else{
-        angles = _euler->getEulerAngles(_grain); // current orientation
-      }
-      neml:: Orientation e = neml::Orientation::createEulerAngles(angles.phi1, angles.Phi, angles.phi2,"degrees");
-      _cpmodel->set_active_orientation(&_hist[_qp].front(),e);
+  if (_euler == nullptr) {
+    mooseWarning("no euler angle file is given for a single default "
+                 "orientation will be used !!!!");
   }
 }
 
-void
-ComputeNEMLCPOutput::stressUpdate(
-      const double * const e_np1, const double * const e_n,
-      const double * const w_np1, const double * const w_n,
-      double T_np1, double T_n, double t_np1, double t_n,
-      double * const s_np1, const double * const s_n,
-      double * const h_np1, const double * const h_n,
-      double * const A_np1, double * const B_np1,
-      double & u_np1, double u_n, double & p_np1, double p_n)
-{
+// Assigning Euler angles from file
+void ComputeNEMLCPOutput::initQpStatefulProperties() {
+  ComputeNEMLStressBase::initQpStatefulProperties();
+  if (_euler != nullptr) {
+    EulerAngles angles;
+    if (_given == 0) {
+      unsigned int grain = std::max(_current_elem->subdomain_id() - 1,
+                                    0);       // to avoid block 0 condition
+      angles = _euler->getEulerAngles(grain); // current orientation
+    } else {
+      angles = _euler->getEulerAngles(_grain); // current orientation
+    }
+    neml::Orientation e = neml::Orientation::createEulerAngles(
+        angles.phi1, angles.Phi, angles.phi2, "degrees");
+    _cpmodel->set_active_orientation(&_hist[_qp].front(), e);
+  }
+}
 
-  ComputeNEMLStressUpdate::stressUpdate(e_np1, e_n, w_np1, w_n, T_np1, T_n, t_np1, t_n,
-               s_np1, s_n, h_np1, h_n, A_np1, B_np1, u_np1, u_n,
-               p_np1, p_n);
+void ComputeNEMLCPOutput::stressUpdate(
+    const double *const e_np1, const double *const e_n,
+    const double *const w_np1, const double *const w_n, double T_np1,
+    double T_n, double t_np1, double t_n, double *const s_np1,
+    const double *const s_n, double *const h_np1, const double *const h_n,
+    double *const A_np1, double *const B_np1, double &u_np1, double u_n,
+    double &p_np1, double p_n) {
+
+  ComputeNEMLStressUpdate::stressUpdate(e_np1, e_n, w_np1, w_n, T_np1, T_n,
+                                        t_np1, t_n, s_np1, s_n, h_np1, h_n,
+                                        A_np1, B_np1, u_np1, u_n, p_np1, p_n);
 
   getCPOutput(h_np1); // passing the history for outputs
 }
 
 // Method to store CP output as material parameters
-void
-ComputeNEMLCPOutput::getCPOutput(double * const h_np1){
+void ComputeNEMLCPOutput::getCPOutput(double *const h_np1) {
 
   _orientation_q[_qp].resize(4);
   neml::Orientation Q = _cpmodel->get_active_orientation(h_np1);
-     for (unsigned int i = 0; i < 4; i++){
-       _orientation_q[_qp][i] = Q.quat()[i];   // assigning quaternion
-     }
+  for (unsigned int i = 0; i < 4; i++) {
+    _orientation_q[_qp][i] = Q.quat()[i]; // assigning quaternion
+  }
 }

--- a/src/materials/ComputeNEMLStrain.C
+++ b/src/materials/ComputeNEMLStrain.C
@@ -2,38 +2,30 @@
 
 registerMooseObject("DeerApp", ComputeNEMLStrain);
 
-template <>
-InputParameters
-validParams<ComputeNEMLStrain>()
-{
-  InputParameters params = validParams<ComputeNEMLStrainBase>();
+InputParameters ComputeNEMLStrain::validParams() {
+  InputParameters params = ComputeNEMLStrainBase::validParams();
   return params;
 }
 
-ComputeNEMLStrain::ComputeNEMLStrain(const InputParameters &
-                                               parameters)
-  : ComputeNEMLStrainBase(parameters)
-{
+ComputeNEMLStrain::ComputeNEMLStrain(const InputParameters &parameters)
+    : ComputeNEMLStrainBase(parameters) {}
 
-}
-
-void
-ComputeNEMLStrain::computeQpProperties()
-{
+void ComputeNEMLStrain::computeQpProperties() {
   ComputeNEMLStrainBase::computeQpProperties();
 
   RankTwoTensor L;
-  
+
   if (_ld) {
-    L = RankTwoTensor::Identity() - _def_grad_old[_qp] * _def_grad[_qp].inverse();
+    L = RankTwoTensor::Identity() -
+        _def_grad_old[_qp] * _def_grad[_qp].inverse();
     _df[_qp] = -L + RankTwoTensor::Identity();
-  }
-  else {
+  } else {
     L = _def_grad[_qp] - _def_grad_old[_qp];
     _df[_qp] = RankTwoTensor::Identity();
   }
 
   _strain_inc[_qp] = (L + L.transpose()) / 2.0;
-  _mechanical_strain_inc[_qp] = (L + L.transpose()) / 2.0 - eigenstrainIncrement();
+  _mechanical_strain_inc[_qp] =
+      (L + L.transpose()) / 2.0 - eigenstrainIncrement();
   _vorticity_inc[_qp] = (L - L.transpose()) / 2.0;
 }

--- a/src/materials/ComputeNEMLStrainBase.C
+++ b/src/materials/ComputeNEMLStrainBase.C
@@ -1,48 +1,45 @@
 #include "ComputeNEMLStrainBase.h"
 
-template <>
-InputParameters
-validParams<ComputeNEMLStrainBase>()
-{
-  InputParameters params = validParams<Material>();
+InputParameters ComputeNEMLStrainBase::validParams() {
+  InputParameters params = Material::validParams();
 
-  params.addRequiredCoupledVar("displacements",
-                               "Displacement variables");
-  params.addParam<bool>("large_kinematics", false, "Use large displacement kinematics.");
-  params.addParam<std::vector<MaterialPropertyName>>("eigenstrain_names", "List of eigenstrains to account for.");
+  params.addRequiredCoupledVar("displacements", "Displacement variables");
+  params.addParam<bool>("large_kinematics", false,
+                        "Use large displacement kinematics.");
+  params.addParam<std::vector<MaterialPropertyName>>(
+      "eigenstrain_names", "List of eigenstrains to account for.");
   params.suppressParameter<bool>("use_displaced_mesh");
 
   return params;
 }
 
-ComputeNEMLStrainBase::ComputeNEMLStrainBase(const InputParameters & parameters)
-  : DerivativeMaterialInterface<Material>(parameters),
-    _ndisp(coupledComponents("displacements")),
-    _disp(3),
-    _grad_disp(3),
-    _strain_inc(declareProperty<RankTwoTensor>("strain_inc")),
-    _mechanical_strain_inc(declareProperty<RankTwoTensor>("mechanical_strain_inc")),
-    _vorticity_inc(declareProperty<RankTwoTensor>("vorticity_inc")),
-    _def_grad(declareProperty<RankTwoTensor>("def_grad")),
-    _def_grad_old(getMaterialPropertyOld<RankTwoTensor>("def_grad")),
-    _df(declareProperty<RankTwoTensor>("df")),
-    _eigenstrain_names(getParam<std::vector<MaterialPropertyName>>("eigenstrain_names")),
-    _eigenstrains(_eigenstrain_names.size()),
-    _eigenstrains_old(_eigenstrain_names.size()),
-    _ld(getParam<bool>("large_kinematics"))
-{
+ComputeNEMLStrainBase::ComputeNEMLStrainBase(const InputParameters &parameters)
+    : DerivativeMaterialInterface<Material>(parameters),
+      _ndisp(coupledComponents("displacements")), _disp(3), _grad_disp(3),
+      _strain_inc(declareProperty<RankTwoTensor>("strain_inc")),
+      _mechanical_strain_inc(
+          declareProperty<RankTwoTensor>("mechanical_strain_inc")),
+      _vorticity_inc(declareProperty<RankTwoTensor>("vorticity_inc")),
+      _def_grad(declareProperty<RankTwoTensor>("def_grad")),
+      _def_grad_old(getMaterialPropertyOld<RankTwoTensor>("def_grad")),
+      _df(declareProperty<RankTwoTensor>("df")),
+      _eigenstrain_names(
+          getParam<std::vector<MaterialPropertyName>>("eigenstrain_names")),
+      _eigenstrains(_eigenstrain_names.size()),
+      _eigenstrains_old(_eigenstrain_names.size()),
+      _ld(getParam<bool>("large_kinematics")) {
   for (unsigned int i = 0; i < _eigenstrain_names.size(); i++) {
-    _eigenstrains[i] = &getMaterialProperty<RankTwoTensor>(_eigenstrain_names[i]);
-    _eigenstrains_old[i] = &getMaterialPropertyOld<RankTwoTensor>(_eigenstrain_names[i]);
+    _eigenstrains[i] =
+        &getMaterialProperty<RankTwoTensor>(_eigenstrain_names[i]);
+    _eigenstrains_old[i] =
+        &getMaterialPropertyOld<RankTwoTensor>(_eigenstrain_names[i]);
   }
 }
 
-void
-ComputeNEMLStrainBase::initialSetup()
-{
+void ComputeNEMLStrainBase::initialSetup() {
   // Enforce consistency
   if (_ndisp != _mesh.dimension()) {
-    paramError("displacements", 
+    paramError("displacements",
                "Number of displacements must match problem dimension.");
   }
 
@@ -58,9 +55,7 @@ ComputeNEMLStrainBase::initialSetup()
   }
 }
 
-void
-ComputeNEMLStrainBase::initQpStatefulProperties()
-{
+void ComputeNEMLStrainBase::initQpStatefulProperties() {
   _strain_inc[_qp].zero();
   _mechanical_strain_inc[_qp].zero();
   _vorticity_inc[_qp].zero();
@@ -68,34 +63,26 @@ ComputeNEMLStrainBase::initQpStatefulProperties()
   _df[_qp] = RankTwoTensor::Identity();
 }
 
-void ComputeNEMLStrainBase::computeProperties()
-{
+void ComputeNEMLStrainBase::computeProperties() {
   precalculate();
   DerivativeMaterialInterface<Material>::computeProperties();
 }
 
-void ComputeNEMLStrainBase::precalculate()
-{
+void ComputeNEMLStrainBase::precalculate() {}
 
-}
-
-RankTwoTensor ComputeNEMLStrainBase::eigenstrainIncrement()
-{
+RankTwoTensor ComputeNEMLStrainBase::eigenstrainIncrement() {
   RankTwoTensor res;
   res.zero();
   for (unsigned int i = 0; i < _eigenstrain_names.size(); i++) {
     res += (*_eigenstrains[i])[_qp];
     res -= (*_eigenstrains_old[i])[_qp];
   }
-  
+
   return res;
 }
 
-void ComputeNEMLStrainBase::computeQpProperties()
-{
-  _def_grad[_qp] = 
-      (RankTwoTensor::Identity() + RankTwoTensor(
-        (*_grad_disp[0])[_qp],
-        (*_grad_disp[1])[_qp],
-        (*_grad_disp[2])[_qp]));
+void ComputeNEMLStrainBase::computeQpProperties() {
+  _def_grad[_qp] = (RankTwoTensor::Identity() +
+                    RankTwoTensor((*_grad_disp[0])[_qp], (*_grad_disp[1])[_qp],
+                                  (*_grad_disp[2])[_qp]));
 }

--- a/src/materials/ComputeNEMLStressUpdate.C
+++ b/src/materials/ComputeNEMLStressUpdate.C
@@ -2,55 +2,40 @@
 
 registerMooseObject("DeerApp", ComputeNEMLStressUpdate);
 
-template <>
-InputParameters
-validParams<ComputeNEMLStressUpdate>()
-{
-  InputParameters params = validParams<ComputeNEMLStressBase>();
+InputParameters ComputeNEMLStressUpdate::validParams() {
+  InputParameters params = ComputeNEMLStressBase::validParams();
 
   return params;
 }
-
 
 // Note: I am not really using use_displaced_mesh, the stress update
 // model doesn't care where it's evaluated.
 // use_displaced_mesh is only used to say "please use a large deformation
 // stress update", consistent with the kernel and the strain material
 ComputeNEMLStressUpdate::ComputeNEMLStressUpdate(
-    const InputParameters & parameters)
-  : ComputeNEMLStressBase(parameters)
-{
+    const InputParameters &parameters)
+    : ComputeNEMLStressBase(parameters) {}
 
-}
-
-void
-ComputeNEMLStressUpdate::stressUpdate(
-      const double * const e_np1, const double * const e_n,
-      const double * const w_np1, const double * const w_n,
-      double T_np1, double T_n, double t_np1, double t_n,
-      double * const s_np1, const double * const s_n,
-      double * const h_np1, const double * const h_n,
-      double * const A_np1, double * const B_np1,
-      double & u_np1, double u_n, double & p_np1, double p_n)
-{
+void ComputeNEMLStressUpdate::stressUpdate(
+    const double *const e_np1, const double *const e_n,
+    const double *const w_np1, const double *const w_n, double T_np1,
+    double T_n, double t_np1, double t_n, double *const s_np1,
+    const double *const s_n, double *const h_np1, const double *const h_n,
+    double *const A_np1, double *const B_np1, double &u_np1, double u_n,
+    double &p_np1, double p_n) {
   int ier;
-  
+
   // Actually call the update
   if (_ld) {
-    ier = _model->update_ld_inc(e_np1, e_n, w_np1, w_n,
-                                T_np1, T_n, t_np1, t_n, 
-                                s_np1, s_n, h_np1, h_n, 
-                                A_np1, B_np1, u_np1, u_n,
-                                p_np1, p_n);
-  }
-  else {
-    ier = _model->update_sd(e_np1, e_n, T_np1, T_n, t_np1, t_n,
-                      s_np1, s_n, h_np1, h_n, A_np1, u_np1, u_n,
-                      p_np1, p_n);
-    std::fill(B_np1, B_np1+18, 0.0);
+    ier = _model->update_ld_inc(e_np1, e_n, w_np1, w_n, T_np1, T_n, t_np1, t_n,
+                                s_np1, s_n, h_np1, h_n, A_np1, B_np1, u_np1,
+                                u_n, p_np1, p_n);
+  } else {
+    ier = _model->update_sd(e_np1, e_n, T_np1, T_n, t_np1, t_n, s_np1, s_n,
+                            h_np1, h_n, A_np1, u_np1, u_n, p_np1, p_n);
+    std::fill(B_np1, B_np1 + 18, 0.0);
   }
 
   if (ier != neml::SUCCESS)
     throw MooseException("NEML stress update failed!");
 }
-

--- a/src/materials/ComputeRadiationSwellingEigenstrain.C
+++ b/src/materials/ComputeRadiationSwellingEigenstrain.C
@@ -5,35 +5,28 @@
 
 registerMooseObject("DeerApp", ComputeRadiationSwellingEigenstrain);
 
-template <>
-InputParameters
-validParams<ComputeRadiationSwellingEigenstrain>()
-{
-  InputParameters params = validParams<ComputeEigenstrainBase>();
-  params.addRequiredParam<FunctionName>("swelling", "Swelling as a function of dose");
-  params.addRequiredParam<FunctionName>("dose_rate", "Dose rate as a function of time");
+InputParameters ComputeRadiationSwellingEigenstrain::validParams() {
+  InputParameters params = ComputeEigenstrainBase::validParams();
+  params.addRequiredParam<FunctionName>("swelling",
+                                        "Swelling as a function of dose");
+  params.addRequiredParam<FunctionName>("dose_rate",
+                                        "Dose rate as a function of time");
   return params;
 }
 
 ComputeRadiationSwellingEigenstrain::ComputeRadiationSwellingEigenstrain(
-    const InputParameters & parameters) :
-    ComputeEigenstrainBase(parameters),
-    _swelling(getFunction("swelling")),
-    _dose_rate(getFunction("dose_rate")),
-    _dose(declareProperty<Real>(_base_name + "dose")),
-    _dose_old(getMaterialPropertyOld<Real>(_base_name + "dose"))
-{
+    const InputParameters &parameters)
+    : ComputeEigenstrainBase(parameters), _swelling(getFunction("swelling")),
+      _dose_rate(getFunction("dose_rate")),
+      _dose(declareProperty<Real>(_base_name + "dose")),
+      _dose_old(getMaterialPropertyOld<Real>(_base_name + "dose")) {}
 
-}
-
-void ComputeRadiationSwellingEigenstrain::initQpStatefulProperties()
-{
+void ComputeRadiationSwellingEigenstrain::initQpStatefulProperties() {
   ComputeEigenstrainBase::initQpStatefulProperties();
   _dose[_qp] = 0.0;
 }
 
-void ComputeRadiationSwellingEigenstrain::computeQpEigenstrain()
-{
+void ComputeRadiationSwellingEigenstrain::computeQpEigenstrain() {
   // Update dose
   _dose[_qp] = _dose_old[_qp] + _dose_rate.value(_t, _q_point[_qp]) * _dt;
 
@@ -45,8 +38,7 @@ void ComputeRadiationSwellingEigenstrain::computeQpEigenstrain()
     for (unsigned j = 0; j < LIBMESH_DIM; ++j) {
       if (i == j) {
         _eigenstrain[_qp](i, j) = swell / 3.0;
-      }
-      else {
+      } else {
         _eigenstrain[_qp](i, j) = 0.0;
       }
     }

--- a/src/materials/ComputeThermalExpansionEigenstrainNEML.C
+++ b/src/materials/ComputeThermalExpansionEigenstrainNEML.C
@@ -3,46 +3,40 @@
 
 registerMooseObject("DeerApp", ComputeThermalExpansionEigenstrainNEML);
 
-template <>
-InputParameters
-validParams<ComputeThermalExpansionEigenstrainNEML>()
-{
-  InputParameters params = validParams<ComputeThermalExpansionEigenstrainBase>();
+InputParameters ComputeThermalExpansionEigenstrainNEML::validParams() {
+  InputParameters params =
+      ComputeThermalExpansionEigenstrainBase::validParams();
   params.addRequiredParam<FileName>("database", "Path to NEML XML database.");
   params.addRequiredParam<std::string>("model", "Model name in NEML database.");
   return params;
 }
 
 ComputeThermalExpansionEigenstrainNEML::ComputeThermalExpansionEigenstrainNEML(
-    const InputParameters & parameters) :
-    ComputeThermalExpansionEigenstrainBase(parameters),
-    _fname(getParam<FileName>("database")),
-    _mname(getParam<std::string>("model")),
-    _tstrain(declareProperty<Real>(_base_name + "tstrain")),
-    _tstrain_old(getMaterialPropertyOld<Real>(_base_name + "tstrain")),
-    _temperature_old(coupledValueOld("temperature"))
-{
+    const InputParameters &parameters)
+    : ComputeThermalExpansionEigenstrainBase(parameters),
+      _fname(getParam<FileName>("database")),
+      _mname(getParam<std::string>("model")),
+      _tstrain(declareProperty<Real>(_base_name + "tstrain")),
+      _tstrain_old(getMaterialPropertyOld<Real>(_base_name + "tstrain")),
+      _temperature_old(coupledValueOld("temperature")) {
   // I strongly hesitate to put this here, may change later
   _model = neml::parse_xml_unique(_fname, _mname);
 }
 
-void
-ComputeThermalExpansionEigenstrainNEML::computeThermalStrain(
-    Real & thermal_strain,
-    Real & instantaneous_cte)
-{
+void ComputeThermalExpansionEigenstrainNEML::computeThermalStrain(
+    Real &thermal_strain, Real &instantaneous_cte) {
   double nemlCTE = _model->alpha(_temperature[_qp]);
   double nemlCTE_old = _model->alpha(_temperature_old[_qp]);
 
-  thermal_strain = _tstrain_old[_qp] + (nemlCTE + nemlCTE_old) / 2 * (
-      _temperature[_qp] - _temperature_old[_qp]);
-  
+  thermal_strain =
+      _tstrain_old[_qp] +
+      (nemlCTE + nemlCTE_old) / 2 * (_temperature[_qp] - _temperature_old[_qp]);
+
   instantaneous_cte = nemlCTE;
   _tstrain[_qp] = thermal_strain;
 }
 
-void ComputeThermalExpansionEigenstrainNEML::initQpStatefulProperties()
-{
+void ComputeThermalExpansionEigenstrainNEML::initQpStatefulProperties() {
   ComputeThermalExpansionEigenstrainBase::initQpStatefulProperties();
   _tstrain[_qp] = 0.0;
 }

--- a/tests/kernels/action/large_action.i
+++ b/tests/kernels/action/large_action.i
@@ -21,25 +21,29 @@
 
 [BCs]
   [./leftx]
-    type = PresetBC
+    type = DirichletBC
+    preset = true
     boundary = left
     variable = disp_x
     value = 0.0
   [../]
   [./lefty]
-    type = PresetBC
+    type = DirichletBC
+    preset = true
     boundary = bottom
     variable = disp_y
     value = 0.0
   [../]
   [./leftz]
-    type = PresetBC
+    type = DirichletBC
+    preset = true
     boundary = back
     variable = disp_z
     value = 0.0
   [../]
   [./pull_z]
-    type = PresetBC
+    type = DirichletBC
+    preset = true
     boundary = front
     variable = disp_z
     value = 0.1

--- a/tests/kernels/action/small_action.i
+++ b/tests/kernels/action/small_action.i
@@ -18,25 +18,29 @@
 
 [BCs]
   [./leftx]
-    type = PresetBC
+    type = DirichletBC
+    preset = true
     boundary = left
     variable = disp_x
     value = 0.0
   [../]
   [./lefty]
-    type = PresetBC
+    type = DirichletBC
+    preset = true
     boundary = bottom
     variable = disp_y
     value = 0.0
   [../]
   [./leftz]
-    type = PresetBC
+    type = DirichletBC
+    preset = true
     boundary = back
     variable = disp_z
     value = 0.0
   [../]
   [./pull_z]
-    type = PresetBC
+    type = DirichletBC
+    preset = true
     boundary = front
     variable = disp_z
     value = 0.1

--- a/tests/kernels/area/area.i
+++ b/tests/kernels/area/area.i
@@ -71,19 +71,22 @@
 
 [BCs]
   [./leftx]
-    type = PresetBC
+    type = DirichletBC
+    preset = true
     boundary = left
     variable = disp_x
     value = 0.0
   [../]
   [./boty]
-    type = PresetBC
+    type = DirichletBC
+    preset = true
     boundary = bottom
     variable = disp_y
     value = 0.0
   [../]
   [./backz]
-    type = PresetBC
+    type = DirichletBC
+    preset = true
     boundary = back
     variable = disp_z
     value = 0.0

--- a/tests/kernels/convergence/1D/oned_dirichlet.i
+++ b/tests/kernels/convergence/1D/oned_dirichlet.i
@@ -35,7 +35,8 @@
 
 [BCs]
   [./leftx]
-    type = PresetBC
+    type = DirichletBC
+    preset = true
     boundary = right
     variable = disp_x
     value = 0.0

--- a/tests/kernels/convergence/1D/oned_neumann.i
+++ b/tests/kernels/convergence/1D/oned_neumann.i
@@ -35,7 +35,8 @@
 
 [BCs]
   [./leftx]
-    type = PresetBC
+    type = DirichletBC
+     preset = true
     boundary = right
     variable = disp_x
     value = 0.0

--- a/tests/kernels/convergence/1D/oned_preset.i
+++ b/tests/kernels/convergence/1D/oned_preset.i
@@ -42,10 +42,11 @@
     value = 0.0
   [../]
   [./pull]
-    type = FunctionPresetBC
+    type = FunctionDirichletBC
     boundary = left
     variable = disp_x
     function = pull
+    preset = true
   [../]
 []
 

--- a/tests/kernels/convergence/1D/oned_preset.i
+++ b/tests/kernels/convergence/1D/oned_preset.i
@@ -35,7 +35,8 @@
 
 [BCs]
   [./leftx]
-    type = PresetBC
+    type = DirichletBC
+    preset = true
     boundary = right
     variable = disp_x
     value = 0.0

--- a/tests/kernels/convergence/2D/dirichlet.i
+++ b/tests/kernels/convergence/2D/dirichlet.i
@@ -48,13 +48,15 @@
 
 [BCs]
   [./leftx]
-    type = PresetBC
+    type = DirichletBC
+     preset = true
     boundary = left
     variable = disp_x
     value = 0.0
   [../]
   [./lefty]
-    type = PresetBC
+    type = DirichletBC
+     preset = true
     boundary = left
     variable = disp_y
     value = 0.0

--- a/tests/kernels/convergence/2D/neumann.i
+++ b/tests/kernels/convergence/2D/neumann.i
@@ -48,13 +48,15 @@
 
 [BCs]
   [./leftx]
-    type = PresetBC
+    type = DirichletBC
+     preset = true
     boundary = left
     variable = disp_x
     value = 0.0
   [../]
   [./lefty]
-    type = PresetBC
+    type = DirichletBC
+     preset = true
     boundary = left
     variable = disp_y
     value = 0.0

--- a/tests/kernels/convergence/2D/preset.i
+++ b/tests/kernels/convergence/2D/preset.i
@@ -62,16 +62,18 @@
     value = 0.0
   [../]
   [./pull_x]
-    type = FunctionPresetBC
+    type = FunctionDirichletBC
     boundary = right
     variable = disp_x
     function = pullx
+    preset = true
   [../]
   [./pull_y]
-    type = FunctionPresetBC
+    type = FunctionDirichletBC
     boundary = top
     variable = disp_y
     function = pully
+    preset = true
   [../]
 []
 

--- a/tests/kernels/convergence/2D/preset.i
+++ b/tests/kernels/convergence/2D/preset.i
@@ -48,13 +48,15 @@
 
 [BCs]
   [./leftx]
-    type = PresetBC
+    type = DirichletBC
+     preset = true
     boundary = left
     variable = disp_x
     value = 0.0
   [../]
   [./lefty]
-    type = PresetBC
+    type = DirichletBC
+     preset = true
     boundary = left
     variable = disp_y
     value = 0.0

--- a/tests/kernels/convergence/3D/dirichlet.i
+++ b/tests/kernels/convergence/3D/dirichlet.i
@@ -61,19 +61,22 @@
 
 [BCs]
   [./leftx]
-    type = PresetBC
+    type = DirichletBC
+    preset = true
     boundary = left
     variable = disp_x
     value = 0.0
   [../]
   [./lefty]
-    type = PresetBC
+    type = DirichletBC
+    preset = true
     boundary = left
     variable = disp_y
     value = 0.0
   [../]
   [./leftz]
-    type = PresetBC
+    type = DirichletBC
+    preset = true
     boundary = left
     variable = disp_z
     value = 0.0

--- a/tests/kernels/convergence/3D/neumann.i
+++ b/tests/kernels/convergence/3D/neumann.i
@@ -61,19 +61,22 @@
 
 [BCs]
   [./leftx]
-    type = PresetBC
+    type = DirichletBC
+    preset = true
     boundary = left
     variable = disp_x
     value = 0.0
   [../]
   [./lefty]
-    type = PresetBC
+    type = DirichletBC
+    preset = true
     boundary = left
     variable = disp_y
     value = 0.0
   [../]
   [./leftz]
-    type = PresetBC
+    type = DirichletBC
+    preset = true
     boundary = left
     variable = disp_z
     value = 0.0

--- a/tests/kernels/convergence/3D/preset.i
+++ b/tests/kernels/convergence/3D/preset.i
@@ -61,19 +61,22 @@
 
 [BCs]
   [./leftx]
-    type = PresetBC
+    type = DirichletBC
+    preset = true
     boundary = left
     variable = disp_x
     value = 0.0
   [../]
   [./lefty]
-    type = PresetBC
+    type = DirichletBC
+    preset = true
     boundary = left
     variable = disp_y
     value = 0.0
   [../]
   [./leftz]
-    type = PresetBC
+    type = DirichletBC
+    preset = true
     boundary = left
     variable = disp_z
     value = 0.0

--- a/tests/kernels/convergence/3D/preset.i
+++ b/tests/kernels/convergence/3D/preset.i
@@ -82,22 +82,25 @@
     value = 0.0
   [../]
   [./pull_x]
-    type = FunctionPresetBC
+    type = FunctionDirichletBC
     boundary = right
     variable = disp_x
     function = pullx
+    preset = true
   [../]
   [./pull_y]
-    type = FunctionPresetBC
+    type = FunctionDirichletBC
     boundary = top
     variable = disp_y
     function = pully
+    preset = true
   [../]
   [./pull_z]
-    type = FunctionPresetBC
+    type = FunctionDirichletBC
     boundary = right
     variable = disp_z
     function = pullz
+    preset = true
   [../]
 []
 

--- a/tests/kernels/convergence/L/L-lll.i
+++ b/tests/kernels/convergence/L/L-lll.i
@@ -47,21 +47,24 @@
 
 [BCs]
   [./left]
-     type = PresetBC
+     type = DirichletBC
+     preset = true
      variable = disp_x
      boundary = fix
      value = 0.0
   [../]
 
   [./bottom]
-    type = PresetBC
+    type = DirichletBC
+    preset = true
     variable = disp_y
     boundary = fix
     value = 0.0
   [../]
 
   [./back]
-    type = PresetBC
+    type = DirichletBC
+    preset = true
     variable = disp_z
     boundary = fix
     value = 0.0

--- a/tests/kernels/convergence/L/L-lll.i
+++ b/tests/kernels/convergence/L/L-lll.i
@@ -71,10 +71,11 @@
   [../]
 
   [./front]
-    type = FunctionPresetBC
+    type = FunctionDirichletBC
     variable = disp_z
     boundary = pull
     function = pfn
+    preset = true
   [../]
 []
 

--- a/tests/kernels/convergence/L/L-sss.i
+++ b/tests/kernels/convergence/L/L-sss.i
@@ -47,21 +47,24 @@
 
 [BCs]
   [./left]
-     type = PresetBC
+     type = DirichletBC
+     preset = true
      variable = disp_x
      boundary = fix
      value = 0.0
   [../]
 
   [./bottom]
-    type = PresetBC
+    type = DirichletBC
+    preset = true
     variable = disp_y
     boundary = fix
     value = 0.0
   [../]
 
   [./back]
-    type = PresetBC
+    type = DirichletBC
+    preset = true
     variable = disp_z
     boundary = fix
     value = 0.0

--- a/tests/kernels/convergence/L/L-sss.i
+++ b/tests/kernels/convergence/L/L-sss.i
@@ -71,10 +71,11 @@
   [../]
 
   [./front]
-    type = FunctionPresetBC
+    type = FunctionDirichletBC
     variable = disp_z
     boundary = pull
     function = pfn
+    preset = true
   [../]
 []
 

--- a/tests/kernels/patch/large_patch.i
+++ b/tests/kernels/patch/large_patch.i
@@ -225,28 +225,32 @@
 
 [BCs]
   [./left]
-     type = PresetBC
+     type = DirichletBC
+     preset = true
      variable = disp_x
      boundary = left
      value = 0.0
   [../]
 
   [./bottom]
-    type = PresetBC
+    type = DirichletBC
+    preset = true
     variable = disp_y
     boundary = bottom
     value = 0.0
   [../]
 
   [./back]
-    type = PresetBC
+    type = DirichletBC
+     preset = true
     variable = disp_z
     boundary = back
     value = 0.0
   [../]
 
   [./front]
-    type = PresetBC
+    type = DirichletBC
+    preset = true
     variable = disp_z
     boundary = front
     value = 0.1

--- a/tests/kernels/patch/small_patch.i
+++ b/tests/kernels/patch/small_patch.i
@@ -225,28 +225,32 @@
 
 [BCs]
   [./left]
-     type = PresetBC
+     type = DirichletBC
+     preset = true
      variable = disp_x
      boundary = left
      value = 0.0
   [../]
 
   [./bottom]
-    type = PresetBC
+    type = DirichletBC
+    preset = true
     variable = disp_y
     boundary = bottom
     value = 0.0
   [../]
 
   [./back]
-    type = PresetBC
+    type = DirichletBC
+    preset = true
     variable = disp_z
     boundary = back
     value = 0.0
   [../]
 
   [./front]
-    type = PresetBC
+    type = DirichletBC
+    preset = true
     variable = disp_z
     boundary = front
     value = 0.1

--- a/tests/kernels/rotation/rotate.i
+++ b/tests/kernels/rotation/rotate.i
@@ -115,31 +115,35 @@
   [../]
 
   [./front_y]
-    type = FunctionPresetBC
+    type = FunctionDirichletBC
     boundary = front
     variable = disp_y
     function = move_y
+    preset = true
   [../]
 
   [./back_y]
-    type = FunctionPresetBC
+    type = FunctionDirichletBC
     boundary = back
     variable = disp_y
     function = move_y
+    preset = true
   [../]
 
   [./front_z]
-    type = FunctionPresetBC
+    type = FunctionDirichletBC
     boundary = front
     variable = disp_z
     function = move_z
+    preset = true
   [../]
 
   [./back_z]
-    type = FunctionPresetBC
+    type = FunctionDirichletBC
     boundary = back
     variable = disp_z
     function = move_z
+    preset = true
   [../]
 
 []

--- a/tests/kernels/rotation/rotate.i
+++ b/tests/kernels/rotation/rotate.i
@@ -107,7 +107,8 @@
 
 [BCs]
   [./fix]
-    type = PresetBC
+    type = DirichletBC
+    preset = true
     value = 0.0
     boundary = left
     variable = disp_x

--- a/tests/kernels/shear/objective_shear.i
+++ b/tests/kernels/shear/objective_shear.i
@@ -203,19 +203,22 @@
 
 [BCs]
   [./back]
-     type = PresetBC
+     type = DirichletBC
+     preset = true
      variable = disp_z
      boundary = back
      value = 0.0
   [../]
   [./bottom_y]
-    type = PresetBC
+    type = DirichletBC
+    preset = true
     variable = disp_y
     boundary = bottom
     value = 0.0
   [../]
   [./bottom_x]
-    type = PresetBC
+    type = DirichletBC
+    preset = true
     variable = disp_x
     boundary = bottom
     value = 0.0
@@ -227,7 +230,8 @@
     function = shearme
   [../]
   [./hmm]
-    type = PresetBC
+    type = DirichletBC
+    preset = true
     variable = disp_y
     boundary = top
     value = 0.0

--- a/tests/kernels/shear/objective_shear.i
+++ b/tests/kernels/shear/objective_shear.i
@@ -224,10 +224,11 @@
     value = 0.0
   [../]
   [./shear]
-    type = FunctionPresetBC
+    type = FunctionDirichletBC
     variable = disp_x
     boundary = top
     function = shearme
+    preset = true
   [../]
   [./hmm]
     type = DirichletBC

--- a/tests/materials/eigenstrain/eigenstrain_3d.i
+++ b/tests/materials/eigenstrain/eigenstrain_3d.i
@@ -17,25 +17,29 @@
 
 [BCs]
   [./x]
-    type = PresetBC
+    type = DirichletBC
+    preset = true
     boundary = left
     variable = disp_x
     value = 0.0
   [../]
   [./right]
-    type = PresetBC
+    type = DirichletBC
+    preset = true
     boundary = right
     variable = disp_x
     value = 0.0
   [../]
   [./y]
-    type = PresetBC
+    type = DirichletBC
+    preset = true
     boundary = bottom
     variable = disp_y
     value = 0.0
   [../]
   [./z]
-    type = PresetBC
+    type = DirichletBC
+     preset = true
     boundary = back
     variable = disp_z
     value = 0.0


### PR DESCRIPTION
we need to update deer to the new InputParameters syntax.
We also need to remove all PresetBC in the tests as they are deprecated. The new standard is DirichletBC with preset=true

closes #24 