### PR TITLE
add realtionship manager to CZM action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .libs
 *-opt
 *-dbg
+*-devel
 *.so
 *.so.*
 *.la

--- a/include/actions/CohesiveZoneMasterActionDeer.h
+++ b/include/actions/CohesiveZoneMasterActionDeer.h
@@ -16,5 +16,9 @@ public:
   static InputParameters validParams();
   CohesiveZoneMasterActionDeer(const InputParameters &params);
 
+  using Action::addRelationshipManagers;
+  virtual void addRelationshipManagers(
+      Moose::RelationshipManagerType input_rm_type) override;
+
   void act() override;
 };

--- a/src/actions/CohesiveZoneMasterActionDeer.C
+++ b/src/actions/CohesiveZoneMasterActionDeer.C
@@ -66,3 +66,14 @@ void CohesiveZoneMasterActionDeer::act() {
     }
   }
 }
+
+void CohesiveZoneMasterActionDeer::addRelationshipManagers(
+    Moose::RelationshipManagerType input_rm_type) {
+
+  std::string kernel_name = getParam<bool>("large_kinematics")
+                                ? "CZMInterfaceKernelPK1"
+                                : "CZMInterfaceKernel";
+
+  InputParameters ips = _factory.getValidParams(kernel_name);
+  addRelationshipManagers(input_rm_type, ips);
+}


### PR DESCRIPTION
This is related to [moose15812](https://github.com/idaholab/moose/pull/15812), which says we need to add relationship managers to actions requiring them.