### PR TITLE
Added thin plate description of induction heating

### DIFF
--- a/examples/reaction/reaction.i
+++ b/examples/reaction/reaction.i
@@ -73,7 +73,6 @@
     type = MaterialRealAux
     variable = reaction_heat
     property = "reaction_power"
-    execute_on = TIMESTEP_END
   [../]
 []
 
@@ -92,8 +91,8 @@
   nl_rel_tol = 1e-6
   nl_abs_tol = 1e-8
 
-  dt = 1.0
-  end_time = 500.0
+  dt = 10.0
+  end_time = 200.0
 []
 
 [Outputs]

--- a/include/functions/InductionFunction.h
+++ b/include/functions/InductionFunction.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "Function.h"
+#include "FunctionInterface.h"
+
+class InductionFunction: public Function, public FunctionInterface {
+ public:
+  static InputParameters validParams();
+  InductionFunction(const InputParameters & parameters);
+
+  virtual Real value(Real t, const Point & p) const;
+
+ protected:
+  Point _center;
+  Point _axis;
+  Real _radius;
+  Real _thickness;
+  Real _delta;
+};

--- a/src/functions/InductionFunction.C
+++ b/src/functions/InductionFunction.C
@@ -1,0 +1,36 @@
+#include "InductionFunction.h"
+
+registerMooseObject("DeerApp", InductionFunction);
+
+InputParameters InductionFunction::validParams() {
+  InputParameters params = Function::validParams();
+
+  params.addRequiredParam<Point>("center", "Center point for calculating r");
+  params.addRequiredParam<Point>("axis", "Tube axis");
+  params.addRequiredParam<Real>("outer_radius", "Tube outer radius");
+  params.addRequiredParam<Real>("thickness", "Tube thickness");
+  params.addRequiredParam<Real>("delta", "Skin depth");
+
+  return params;
+};
+
+InductionFunction::InductionFunction(const InputParameters & parameters) :
+    Function(parameters), FunctionInterface(this),
+    _center(getParam<Point>("center")),
+    _axis(getParam<Point>("axis")),
+    _radius(getParam<Real>("outer_radius")),
+    _thickness(getParam<Real>("thickness")),
+    _delta(getParam<Real>("delta"))
+{
+
+}
+
+Real
+InductionFunction::value(Real t, const Point & p) const
+{
+  Real r = (p - _center).cross(_axis).norm() / _axis.norm();
+  Real x = _radius - r;
+  
+  return std::exp(-2*x/_delta) / (
+      M_PI * _radius * _delta * (1.0 - std::exp(-2*_thickness / _delta)));
+}

--- a/src/kernels/AdiabaticHeating.C
+++ b/src/kernels/AdiabaticHeating.C
@@ -25,5 +25,5 @@ AdiabaticHeating::AdiabaticHeating(const InputParameters & parameters) :
 Real
 AdiabaticHeating::computeQpResidual()
 {
-  return _test[_i][_qp] * _fraction * _heat[_qp];
+  return -_test[_i][_qp] * _fraction * _heat[_qp];
 }


### PR DESCRIPTION
Adds a simplified description of induction heat for hollow tubes based on thin shell theory.

Corrects AdiabaticHeating kernel to give it the right sign.