### PR TITLE
Add ExplodeMeshGenerator

### DIFF
--- a/include/meshgenerators/ExplodeMeshGenerator.h
+++ b/include/meshgenerators/ExplodeMeshGenerator.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "MeshGenerator.h"
+
+/*
+ * A mesh generator to split a mesh by breaking all element-element interfaces in the
+ * specified subdomains
+ */
+class ExplodeMeshGenerator : public MeshGenerator
+{
+public:
+  static InputParameters validParams();
+
+  ExplodeMeshGenerator(const InputParameters & parameters);
+
+  std::unique_ptr<MeshBase> generate() override;
+
+protected:
+  std::unordered_map<dof_id_type, std::vector<dof_id_type>>
+  buildSubdomainRestrictedNodeToElemMap(std::unique_ptr<MeshBase> & mesh,
+                                        const std::vector<SubdomainID> & subdomains) const;
+
+  void duplicateNodes(
+      std::unique_ptr<MeshBase> & mesh,
+      const std::unordered_map<dof_id_type, std::vector<dof_id_type>> & node_to_elem_map) const;
+
+  void duplicateNode(std::unique_ptr<MeshBase> & mesh, Elem * elem, const Node * node) const;
+
+  void createInterface(
+      MeshBase & mesh,
+      const std::unordered_map<dof_id_type, std::vector<dof_id_type>> & node_to_elem_map) const;
+
+  /// The mesh to modify
+  std::unique_ptr<MeshBase> & _input;
+
+  // The subdomains to explode
+  const std::vector<SubdomainID> & _subdomains;
+
+  // The name of the new boundary
+  const BoundaryName _interface_name;
+};

--- a/include/meshgenerators/ExplodeMeshGenerator.h
+++ b/include/meshgenerators/ExplodeMeshGenerator.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "MeshGenerator.h"
+#include "libmesh/elem.h"
 
 /*
  * A mesh generator to split a mesh by breaking all element-element interfaces in the

--- a/src/meshgenerators/ExplodeMeshGenerator.C
+++ b/src/meshgenerators/ExplodeMeshGenerator.C
@@ -1,0 +1,143 @@
+#include "ExplodeMeshGenerator.h"
+#include "libmesh/partitioner.h"
+
+registerMooseObject("MooseApp", ExplodeMeshGenerator);
+
+InputParameters
+ExplodeMeshGenerator::validParams()
+{
+  InputParameters params = MeshGenerator::validParams();
+  params.addClassDescription("Break all element-element interfaces in the specified subdomains.");
+  params.addRequiredParam<MeshGeneratorName>("input", "The mesh we want to modify");
+  params.addParam<std::vector<SubdomainID>>("subdomains",
+                                            "The list of subdomain names to explode.");
+  params.addRequiredParam<BoundaryName>(
+      "interface_name", "The boundary name containing all broken element-element interfaces.");
+  return params;
+}
+
+ExplodeMeshGenerator::ExplodeMeshGenerator(const InputParameters & parameters)
+  : MeshGenerator(parameters),
+    _input(getMesh("input")),
+    _subdomains(getParam<std::vector<SubdomainID>>("subdomains")),
+    _interface_name(getParam<BoundaryName>("interface_name"))
+{
+}
+
+std::unique_ptr<MeshBase>
+ExplodeMeshGenerator::generate()
+{
+  std::unique_ptr<MeshBase> mesh = std::move(_input);
+
+  BoundaryInfo & boundary_info = mesh->get_boundary_info();
+  if (boundary_info.get_id_by_name(_interface_name) != Moose::INVALID_BOUNDARY_ID)
+    paramError("interface_name", "The specified interface name already exits in the mesh.");
+
+  const auto node_to_elem_map = buildSubdomainRestrictedNodeToElemMap(mesh, _subdomains);
+
+  duplicateNodes(mesh, node_to_elem_map);
+
+  createInterface(*mesh, node_to_elem_map);
+
+  Partitioner::set_node_processor_ids(*mesh);
+
+  return dynamic_pointer_cast<MeshBase>(mesh);
+}
+
+std::unordered_map<dof_id_type, std::vector<dof_id_type>>
+ExplodeMeshGenerator::buildSubdomainRestrictedNodeToElemMap(
+    std::unique_ptr<MeshBase> & mesh, const std::vector<SubdomainID> & subdomains) const
+{
+  std::unordered_map<dof_id_type, std::vector<dof_id_type>> node_to_elem_map;
+  for (const auto & elem : mesh->active_element_ptr_range())
+  {
+    // Skip if the element is not in the specified subdomains
+    if (std::find(subdomains.begin(), subdomains.end(), elem->subdomain_id()) == subdomains.end())
+      continue;
+
+    std::set<const Elem *> neighbors;
+    elem->find_point_neighbors(neighbors);
+
+    for (auto n : make_range(elem->n_nodes()))
+    {
+      // if ANY neighboring element that contains this node is not in the specified subdomains,
+      // don't add this node to the map, i.e. don't split this node.
+      bool should_duplicate = true;
+      for (auto neighbor : neighbors)
+        if (neighbor->contains_point(elem->node_ref(n)) &&
+            std::find(subdomains.begin(), subdomains.end(), neighbor->subdomain_id()) ==
+                subdomains.end())
+        {
+          should_duplicate = false;
+          break;
+        }
+
+      if (should_duplicate)
+        node_to_elem_map[elem->node_id(n)].push_back(elem->id());
+    }
+  }
+  return node_to_elem_map;
+}
+
+void
+ExplodeMeshGenerator::duplicateNodes(
+    std::unique_ptr<MeshBase> & mesh,
+    const std::unordered_map<dof_id_type, std::vector<dof_id_type>> & node_to_elem_map) const
+{
+  for (const auto & [node_id, connected_elem_ids] : node_to_elem_map)
+    for (auto i : make_range(connected_elem_ids.size() - 1))
+      duplicateNode(mesh, mesh->elem_ptr(connected_elem_ids[i]), mesh->node_ptr(node_id));
+}
+
+void
+ExplodeMeshGenerator::duplicateNode(std::unique_ptr<MeshBase> & mesh,
+                                    Elem * elem,
+                                    const Node * node) const
+{
+  Node * new_node = nullptr;
+  new_node = Node::build(*node, mesh->n_nodes()).release();
+  new_node->processor_id() = elem->processor_id();
+  mesh->add_node(new_node);
+  for (auto j : make_range(elem->n_nodes()))
+    if (elem->node_id(j) == node->id())
+    {
+      elem->set_node(j) = new_node;
+      break;
+    }
+
+  // Add boundary info to the new node
+  BoundaryInfo & boundary_info = mesh->get_boundary_info();
+  std::vector<boundary_id_type> node_boundary_ids;
+  boundary_info.boundary_ids(node, node_boundary_ids);
+  boundary_info.add_node(new_node, node_boundary_ids);
+}
+
+void
+ExplodeMeshGenerator::createInterface(
+    MeshBase & mesh,
+    const std::unordered_map<dof_id_type, std::vector<dof_id_type>> & node_to_elem_map) const
+{
+  BoundaryInfo & boundary_info = mesh.get_boundary_info();
+  const auto & existing_boundary_ids = boundary_info.get_boundary_ids();
+  boundary_id_type interface_id =
+      existing_boundary_ids.empty() ? 0 : *existing_boundary_ids.rbegin() + 1;
+  boundary_info.sideset_name(interface_id) = _interface_name;
+
+  std::set<std::pair<dof_id_type, unsigned int>> sides_to_add;
+
+  for (const auto & [node_id, connected_elem_ids] : node_to_elem_map)
+    for (const auto & elem_id_i : connected_elem_ids)
+      for (const auto & elem_id_j : connected_elem_ids)
+      {
+        Elem * elem_i = mesh.elem_ptr(elem_id_i);
+        Elem * elem_j = mesh.elem_ptr(elem_id_j);
+        if (elem_i != elem_j && elem_i->id() < elem_j->id() && elem_i->has_neighbor(elem_j))
+        {
+          unsigned int side = elem_i->which_neighbor_am_i(elem_j);
+          sides_to_add.insert(std::make_pair(elem_id_i, side));
+        }
+      }
+
+  for (const auto & [elem_id, side] : sides_to_add)
+    boundary_info.add_side(elem_id, side, interface_id);
+}

--- a/src/meshgenerators/ExplodeMeshGenerator.C
+++ b/src/meshgenerators/ExplodeMeshGenerator.C
@@ -1,4 +1,6 @@
 #include "ExplodeMeshGenerator.h"
+#include "CastUniquePointer.h"
+
 #include "libmesh/partitioner.h"
 
 registerMooseObject("MooseApp", ExplodeMeshGenerator);


### PR DESCRIPTION
This mesh generator breaks all element-element interfaces in given subdomains. Then we can add cohesive elements everywhere.

I have the PR up in MOOSE https://github.com/idaholab/moose/pull/21061
but if we want to use this capability before that is merged, here it is.